### PR TITLE
Update docker image with profile step time

### DIFF
--- a/training/trillium/Llama3-8B-PyTorch/GCE/README.md
+++ b/training/trillium/Llama3-8B-PyTorch/GCE/README.md
@@ -29,16 +29,16 @@ gcloud alpha compute tpus tpu-vm create $TPU_NAME \
 The following setup runs the training job with Llama 3 8B on GCE TPUs using
 the docker image from this registry
 (`us-central1-docker.pkg.dev/deeplearning-images/reproducibility/pytorch-tpu-llama:v1`).
-The docker image uses torch and torch_xla nightly build from 01/16/2025
+The docker image uses torch and torch_xla nightly build from 02/11/2025
 and comes with all the package dependency needed to run the model training.
 All the command below should run from your own machine (not the TPU host you
-created).
+created). The Dockerfile is at https://github.com/pytorch-tpu/transformers/blob/flash_attention/Dockerfile
 
 1. git clone and navigate to this README repo and run training script:
 
 ```bash
 git clone --depth 1 https://github.com/AI-Hypercomputer/tpu-recipes.git
-cd training/trillium/GCE/Llama3-8B-PyTorch
+cd training/trillium/Llama3-8B-PyTorch/GCE
 ```
 
 2. Edit `env.sh` to add the hugging face token and/or setup the training parameters.

--- a/training/trillium/Llama3-8B-PyTorch/GCE/host.sh
+++ b/training/trillium/Llama3-8B-PyTorch/GCE/host.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-DOCKER_IMAGE=us-central1-docker.pkg.dev/deeplearning-images/reproducibility/pytorch-tpu-llama:v1
-
+DOCKER_IMAGE=us-central1-docker.pkg.dev/deeplearning-images/reproducibility/pytorch-tpu-llama:v2
 worker_id=$(curl -s "http://metadata.google.internal/computeMetadata/v1/instance/attributes/agent-worker-number" -H 'Metadata-Flavor: Google')
 
 cat >> /dev/null <<EOF


### PR DESCRIPTION
The new docker image analyzes the locally stored profiles to get the step time and report that in the script.

The output looks like the following:
```
[worker 0] Parsing /tmp/home/profile/plugins/profile/2025_02_14_00_13_42/127.0.0.1_9012.xplane.pb
[worker 0] Plane ID: 2, Name: /device:TPU:0
[worker 0]   Line ID: 2, Name: XLA Modules
[worker 0]     Event Metadata Name: SyncTensorsGraph.66628(14940262714490726846), ID: 25941, Duration: 2.904149665406 s
[worker 0]     Event Metadata Name: SyncTensorsGraph.66628(14940262714490726846), ID: 25941, Duration: 2.901553873328 s
[worker 0]     Event Metadata Name: SyncTensorsGraph.66628(14940262714490726846), ID: 25941, Duration: 2.905248442828 s
[worker 0]     Event Metadata Name: SyncTensorsGraph.66628(14940262714490726846), ID: 25941, Duration: 2.9037382375 s
[worker 0]     Event Metadata Name: SyncTensorsGraph.66628(14940262714490726846), ID: 25941, Duration: 2.90603396 s
[worker 0]     Event Metadata Name: SyncTensorsGraph.66628(14940262714490726846), ID: 25941, Duration: 2.903193477172 s
[worker 0]     Event Metadata Name: SyncTensorsGraph.66628(14940262714490726846), ID: 25941, Duration: 2.905565544234 s
[worker 0]     Event Metadata Name: SyncTensorsGraph.66628(14940262714490726846), ID: 25941, Duration: 2.902798507172 s
[worker 0]     Event Metadata Name: SyncTensorsGraph.66628(14940262714490726846), ID: 25941, Duration: 2.90552500525 s
[worker 0]     Event Metadata Name: SyncTensorsGraph.66628(14940262714490726846), ID: 25941, Duration: 2.902875035156 s
[worker 0]     Event Metadata Name: SyncTensorsGraph.66628(14940262714490726846), ID: 25941, Duration: 2.905281515078 s
[worker 0]     Event Metadata Name: SyncTensorsGraph.66628(14940262714490726846), ID: 25941, Duration: 2.902723529422 s
[worker 0]     Event Metadata Name: SyncTensorsGraph.66628(14940262714490726846), ID: 25941, Duration: 2.905252619422 s
[worker 0] Got 13 iterations
100%|██████████| 20/20 [18:33<00:00, 55.67s/it]
[worker 0] [INFO|modelcard.py:450] 2025-02-14 00:20:15,207 >> Dropping the following result as it does not have all the necessary fields:
[worker 0] {'task': {'name': 'Causal Language Modeling', 'type': 'text-generation'}, 'dataset': {'name': 'wikitext wikitext-103-raw-v1', 'type': 'wikitext', 'args': 'wikitext-103-raw-v1'}}
[worker 0] {'train_runtime': 37.7539, 'train_samples_per_second': 5.509, 'train_steps_per_second': 0.344, 'train_loss': 10.780475616455078, 'epoch': 0.01}
[worker 0] ***** train metrics *****
[worker 0]   epoch                    =     0.0111
[worker 0]   total_flos               = 54967710GF
[worker 0]   train_loss               =    10.7805
[worker 0]   train_runtime            = 0:00:37.75
[worker 0]   train_samples_per_second =      5.509
[worker 0]   train_steps_per_second   =      0.344
```