### PR TITLE
Update PyTorch Llama3 70B recipe to calculate metrics from profile

### DIFF
--- a/training/trillium/Llama3-70B-PyTorch/GCE/README.md
+++ b/training/trillium/Llama3-70B-PyTorch/GCE/README.md
@@ -28,17 +28,17 @@ gcloud alpha compute tpus tpu-vm create $TPU_NAME \
 
 The following setup runs the training job with Llama 3 70B on GCE TPUs using
 the docker image from this registry
-(`us-central1-docker.pkg.dev/deeplearning-images/reproducibility/pytorch-xla/llama3-70b:jan15built`).
-The docker image uses torch and torch_xla nightly build from 09/28/2024
+(`us-central1-docker.pkg.dev/deeplearning-images/reproducibility/pytorch-xla/llama3-70b:feb14build`).
+The docker image uses torch and torch_xla nightly build from 02/11/2024
 and comes with all the package dependency needed to run the model training.
 All the command below should run from your own machine (not the TPU host you
-created).
+created). The dockerfile used is to build the image is at https://github.com/AI-Hypercomputer/tpu-recipes/blob/main/training/trillium/Llama3-70B-PyTorch/GCE/tpu.Dockerfile
 
 1. git clone and navigate to this README repo and run training script:
 
 ```bash
 git clone --depth 1 https://github.com/AI-Hypercomputer/tpu-recipes.git
-cd training/trillium/GCE/Llama3-70B-PyTorch
+cd training/trillium/Llama3-70B-PyTorch/GCE
 ```
 
 2. Edit `env.sh` to add the hugging face token and/or setup the training parameters.

--- a/training/trillium/Llama3-70B-PyTorch/GCE/host.sh
+++ b/training/trillium/Llama3-70B-PyTorch/GCE/host.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-DOCKER_IMAGE=us-central1-docker.pkg.dev/deeplearning-images/reproducibility/pytorch-xla/llama3-70b:jan15built
-
+DOCKER_IMAGE=us-central1-docker.pkg.dev/deeplearning-images/reproducibility/pytorch-xla/llama3-70b:feb14build
 worker_id=$(curl -s "http://metadata.google.internal/computeMetadata/v1/instance/attributes/agent-worker-number" -H 'Metadata-Flavor: Google')
 
 cat >> /dev/null <<EOF

--- a/training/trillium/Llama3-70B-PyTorch/GCE/tpu.Dockerfile
+++ b/training/trillium/Llama3-70B-PyTorch/GCE/tpu.Dockerfile
@@ -1,6 +1,5 @@
 # Base package containing nightly PyTorch/XLA
-ARG BASE_IMAGE=us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:nightly_3.10_tpuvm
-FROM ${BASE_IMAGE}
+FROM us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:nightly_3.10_tpuvm_cxx11_20250211
 
 # Install transformers library
 ARG TRANSFORMERS_REPO=https://github.com/pytorch-tpu/transformers.git
@@ -10,7 +9,7 @@ RUN git clone "${TRANSFORMERS_REPO}" transformers && cd transformers && git chec
 
 # Install transformers dependencies
 WORKDIR /workspace/transformers
-RUN pip3 install git+file://$PWD accelerate datasets evaluate "huggingface_hub[cli]" \
+RUN pip3 install git+file://$PWD accelerate datasets protobuf evaluate "huggingface_hub[cli]" \
     "torch_xla[pallas]" \
     -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html \
     -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html


### PR DESCRIPTION
The output of the script looks as follows:

```
[worker 0] Training completed. Do not forget to share your model on huggingface.co/models =)
[worker 0] 
[worker 0] 
[worker 0] Parsing /tmp/home/profile/plugins/profile/2025_02_14_00_13_42/127.0.0.1_9012.xplane.pb
[worker 0] Plane ID: 2, Name: /device:TPU:0
[worker 0]   Line ID: 2, Name: XLA Modules
[worker 0]     Event Metadata Name: SyncTensorsGraph.66628(14940262714490726846), ID: 25941, Duration: 2.904149665406 s
[worker 0]     Event Metadata Name: SyncTensorsGraph.66628(14940262714490726846), ID: 25941, Duration: 2.901553873328 s
[worker 0]     Event Metadata Name: SyncTensorsGraph.66628(14940262714490726846), ID: 25941, Duration: 2.905248442828 s
[worker 0]     Event Metadata Name: SyncTensorsGraph.66628(14940262714490726846), ID: 25941, Duration: 2.9037382375 s
[worker 0]     Event Metadata Name: SyncTensorsGraph.66628(14940262714490726846), ID: 25941, Duration: 2.90603396 s
[worker 0]     Event Metadata Name: SyncTensorsGraph.66628(14940262714490726846), ID: 25941, Duration: 2.903193477172 s
[worker 0]     Event Metadata Name: SyncTensorsGraph.66628(14940262714490726846), ID: 25941, Duration: 2.905565544234 s
[worker 0]     Event Metadata Name: SyncTensorsGraph.66628(14940262714490726846), ID: 25941, Duration: 2.902798507172 s
[worker 0]     Event Metadata Name: SyncTensorsGraph.66628(14940262714490726846), ID: 25941, Duration: 2.90552500525 s
[worker 0]     Event Metadata Name: SyncTensorsGraph.66628(14940262714490726846), ID: 25941, Duration: 2.902875035156 s
[worker 0]     Event Metadata Name: SyncTensorsGraph.66628(14940262714490726846), ID: 25941, Duration: 2.905281515078 s
[worker 0]     Event Metadata Name: SyncTensorsGraph.66628(14940262714490726846), ID: 25941, Duration: 2.902723529422 s
[worker 0]     Event Metadata Name: SyncTensorsGraph.66628(14940262714490726846), ID: 25941, Duration: 2.905252619422 s
[worker 0] Got 13 iterations
100%|██████████| 20/20 [04:39<00:00, 13.99s/it]
[worker 0] [INFO|modelcard.py:450] 2025-02-14 22:28:15,027 >> Dropping the following result as it does not have all the necessary fields:
[worker 0] {'task': {'name': 'Causal Language Modeling', 'type': 'text-generation'}, 'dataset': {'name': 'wikitext wikitext-103-raw-v1', 'type': 'wikitext', 'args': 'wikitext-103-raw-v1'}}
[worker 0] {'train_runtime': 37.7539, 'train_samples_per_second': 1.377, 'train_steps_per_second': 0.344, 'train_loss': 9.57159881591797, 'epoch': 0.01}
[worker 0] ***** train metrics *****
[worker 0]   epoch                    =     0.0057
[worker 0]   total_flos               =  4688805GF
[worker 0]   train_loss               =     9.5716
[worker 0]   train_runtime            = 0:00:37.75
[worker 0]   train_samples_per_second =      1.377
[worker 0]   train_steps_per_second   =      0.344

```