### PR TITLE
Update the recipe for DeepSeek-R1-Distill-Llama-70B on Trillium to pin JAX version

### DIFF
--- a/inference/trillium/JetStream-Maxtext/DeepSeek-R1-Distill-Llama-70B/gke/docker/Dockerfile
+++ b/inference/trillium/JetStream-Maxtext/DeepSeek-R1-Distill-Llama-70B/gke/docker/Dockerfile
@@ -42,14 +42,14 @@ RUN update-alternatives --install \
 RUN git clone https://github.com/AI-Hypercomputer/maxtext.git && \
 git clone https://github.com/AI-Hypercomputer/JetStream.git
 
-RUN cd maxtext/ && \
-bash setup.sh
-
 RUN cd /JetStream && \
 pip install -e .
 
 RUN cd /JetStream/benchmarks && \
 pip install -r requirements.in
+
+RUN cd maxtext/ && \
+bash setup.sh JAX_VERSION=0.5.0
 
 # Reset working directory to /workspace
 WORKDIR /workspace

--- a/inference/trillium/JetStream-Maxtext/DeepSeek-R1-Distill-Llama-70B/tpu-vm/README.md
+++ b/inference/trillium/JetStream-Maxtext/DeepSeek-R1-Distill-Llama-70B/tpu-vm/README.md
@@ -148,7 +148,7 @@ pip install -r requirements.in
 ```
 cd ~
 cd maxtext/
-bash setup.sh
+bash setup.sh JAX_VERSION=0.5.0
 ```
 
 * Install additional dependencies


### PR DESCRIPTION
Update the recipe for DeepSeek-R1-Distill-Llama-70B on Trillium to pin JAX version