### PR TITLE
Add MaxText workload config to v6e-8 recipe READMEs

### DIFF
--- a/training/trillium/Llama3-8B-MaxText/v6e-8/README.md
+++ b/training/trillium/Llama3-8B-MaxText/v6e-8/README.md
@@ -42,3 +42,53 @@ From your workload logs, you should start seeing step time logs like the followi
 completed step: 7, seconds: 3.416, TFLOP/s/device: 416.601, Tokens/s/device: 7193.579, total_weights: 196608, loss: 6.634
 ```
 If you would like to run on multiple slices of v6e-8, you may modify the `--num_slices` flag.
+
+### Workload Details
+
+For reference, here are the `llama3_1_8b_8192_no_collective_matmul` workload details as found in `MaxText@tpu-recipes-v0.1.0`:
+
+```
+  MaxTextModel(
+    model_name="llama3_1-8b-8192-no-collective-matmul",
+    model_type="llama3.1-8b",
+    tuning_params={
+        "per_device_batch_size": 3,
+        "ici_fsdp_parallelism": -1,
+        "remat_policy": "custom",
+        "decoder_layer_input": "offload",
+        "out_proj": "offload",
+        "query_proj": "offload",
+        "key_proj": "offload",
+        "value_proj": "offload",
+        "max_target_length": 8192,
+        "attention": "flash",
+        "use_iota_embed": True,
+        "dataset_path": "gs://max-datasets-rogue",
+        "dataset_type": "synthetic",
+        "enable_checkpointing": False,
+        "sa_block_q": 2048,
+        "sa_block_kv": 2048,
+        "sa_block_kv_compute": 2048,
+        "sa_block_q_dkv": 2048,
+        "sa_block_kv_dkv": 2048,
+        "sa_block_kv_dkv_compute": 2048,
+        "sa_block_q_dq": 2048,
+        "sa_block_kv_dq": 2048,
+        "sa_use_fused_bwd_kernel": True,
+        "profiler": "xplane",
+        "skip_first_n_steps_for_profiler": 10,
+        "profiler_steps": 5,
+    },
+    xla_flags=(
+        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+        + xla_flags_library.LAYOUT_FOR_ALL_REDUCE_SCATTER
+        + xla_flags_library.DATA_PARALLEL_OVERLAP
+        + xla_flags_library.CF_FOR_ALL_GATHER
+        + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE
+        + xla_flags_library.HOST_OFFLOAD_FLAGS
+        + xla_flags_library.DISABLE_COLLECTIVE_MATMUL
+    ),
+  )
+```
+
+This equivalent workload code can be found in the [maxtext_trillium_model_configs.py](https://github.com/AI-Hypercomputer/maxtext/blob/tpu-recipes-v0.1.0/benchmarks/maxtext_trillium_model_configs.py#L858-L901) file within the MaxText repository.

--- a/training/trillium/Mistral-7B-MaxText/README.md
+++ b/training/trillium/Mistral-7B-MaxText/README.md
@@ -42,3 +42,53 @@ From your workload logs, you should start seeing step time logs like the followi
 completed step: 7, seconds: 6.051, TFLOP/s/device: 451.236, Tokens/s/device: 8123.462, total_weights: 393216, loss: 6.765
 ```
 If you would like to run on multiple slices of v6e-8, you may modify the `--num_slices` flag.
+
+### Workload Details
+
+For reference, here are the `llama3_1_8b_8192_no_collective_matmul` workload details as found in `MaxText@tpu-recipes-v0.1.0`:
+
+```
+  MaxTextModel(
+    model_name="mistral-7b",
+    model_type="mistral-7b",
+    tuning_params={
+        "per_device_batch_size": 6,
+        "ici_fsdp_parallelism": -1,
+        "remat_policy": "custom",
+        "decoder_layer_input": "offload",
+        "out_proj": "offload",
+        "query_proj": "offload",
+        "key_proj": "offload",
+        "value_proj": "offload",
+        "max_target_length": 8192,
+        "attention": "flash",
+        "use_iota_embed": True,
+        "dataset_path": "gs://max-datasets-rogue",
+        "dataset_type": "synthetic",
+        "enable_checkpointing": False,
+        "sa_block_q": 2048,
+        "sa_block_kv": 2048,
+        "sa_block_kv_compute": 2048,
+        "sa_block_q_dkv": 2048,
+        "sa_block_kv_dkv": 2048,
+        "sa_block_kv_dkv_compute": 2048,
+        "sa_block_q_dq": 2048,
+        "sa_block_kv_dq": 2048,
+        "sa_use_fused_bwd_kernel": True,
+        "profiler": "xplane",
+        "skip_first_n_steps_for_profiler": 10,
+        "profiler_steps": 5,
+    },
+    xla_flags=(
+        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+        + xla_flags_library.LAYOUT_FOR_ALL_REDUCE_SCATTER
+        + xla_flags_library.DATA_PARALLEL_OVERLAP
+        + xla_flags_library.CF_FOR_ALL_GATHER
+        + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE
+        + xla_flags_library.HOST_OFFLOAD_FLAGS
+        + xla_flags_library.DISABLE_COLLECTIVE_MATMUL
+    ),
+  )
+```
+
+This equivalent workload code can be found in the [maxtext_trillium_model_configs.py](https://github.com/AI-Hypercomputer/maxtext/blob/tpu-recipes-v0.1.0/benchmarks/maxtext_trillium_model_configs.py#L1189-L1232) file within the MaxText repository.


### PR DESCRIPTION
# Notes

Show the workload's MaxText config directly in the tpu-recipe README. Making this change for the recently added v6e-8 recipes. It will also be included in the upcoming v6e-256 recipe modifications.

This works because we are pointing to a specific MaxText release (`tpu-recipes-v0.1.0`), so this config won't change for that point in time.