### PR TITLE
Add Llama3.1-405B MaxText recipe

### DIFF
--- a/training/trillium/Llama3.1-405B-MaxText/llama3-1-405b-2xv6e-256.sh
+++ b/training/trillium/Llama3.1-405B-MaxText/llama3-1-405b-2xv6e-256.sh
@@ -1,0 +1,9 @@
+python3 benchmarks/benchmark_runner.py xpk \
+    --project=$PROJECT \
+    --zone=$ZONE \
+    --device_type=v6e-256 \
+    --num_slices=2  \
+    --cluster_name=${CLUSTER_NAME} \
+    --base_output_directory=${OUTPUT_DIR} \
+    --model_name="llama3_1_405b_8192_pure_fsdp_ici" \
+    --base_docker_image=maxtext_base_image

--- a/training/trillium/Llama3.1-405B-MaxText/llama3-405b-2xv6e-256.sh
+++ b/training/trillium/Llama3.1-405B-MaxText/llama3-405b-2xv6e-256.sh
@@ -1,2 +1,0 @@
-python3 benchmarks/benchmark_runner.py --project=$PROJECT --zone=$ZONE --device_type=v6e-256 --num_slices=2  --cluster_name=${CLUSTER_NAME} --base_output_directory=${OUTPUT_DIR} \
---model_name="llama3_1_405b_8192_fsdp_dcn" --libtpu_version=20241028 --base_docker_image maxtext_base_image


### PR DESCRIPTION
Updating the Llama3.1-405B recipe to use the `tpu-recipes-v0.1.0` tag. Also used a more optimized benchmark from @gobbleturk.

### Tests
* Ran this recipe on 2 slices of v6e-256 and got 412 TFLOPs