### PR TITLE
Micro-benchmarks for matmul and HBM bandwidth

### DIFF
--- a/microbenchmarks/README.md
+++ b/microbenchmarks/README.md
@@ -1,0 +1,58 @@
+# Microbenchmarks
+
+## Setup
+
+Set up a v6e TPU VM:
+```
+gcloud compute tpus tpu-vm create $TPU_NAME /
+        --zone=$ZONE /
+        --accelerator-type=v6e-1  /
+        --version=v2-alpha-tpuv6e
+```
+See https://cloud.google.com/tpu/docs/regions-zones for available zones.
+
+SSH into the VM:
+```
+gcloud compute ssh $TPU_NAME --zone=$ZONE
+```
+
+Clone the repo and install the dependencies:
+```bash
+git clone https://github.com/chishuen/tpu-recipes.git
+cd tpu-recipes/microbenchmarks
+pip install -r requirements.txt
+```
+
+## Run Matmul Benchmark
+
+Usage example:
+```
+python benchmark_matmul.py \
+  --dim 4096 4096 4096 \
+  --libtpu_args=--xla_tpu_scoped_vmem_limit_kib=65536 \
+  --matcher="jit_matmul.*"
+```
+
+Example output:
+```
+dtype: bfloat16, matrix Dimensions: (16384, 16384, 16384), time taken (median): 10.584555 ms, TFLOPs/sec: 831.0309712791892
+```
+
+Run `python benchmark_matmul.py -h` to view the how to set the arguments.
+
+
+## HBM Bandwidth Benchmark
+
+Usage example:
+```
+python benchmark_hbm.py \
+  --num_elements=16777216 \
+  --matcher="jit_my_copy.*"
+```
+
+Example output:
+```
+Tensor size: 32.0 MBs, time taken (median): 0.0461 ms, bandwidth: 1454.54 GBps
+```
+
+Run `python benchmark_hbm.py -h` to view the how to set the arguments.

--- a/microbenchmarks/benchmark_hbm.py
+++ b/microbenchmarks/benchmark_hbm.py
@@ -30,10 +30,8 @@ def get_dtype(dtype: str):
 
 
 def main() -> dict[str, Any]:
-  """Benchmark for HBM bandwidth.
+  """Benchmark for HBM bandwidth."""
 
-  Returns: a dict summarizing the benchmark result.
-  """
   parser = argparse.ArgumentParser(
       description="Run HBM bandwidth benchmark."
   )
@@ -125,17 +123,8 @@ def main() -> dict[str, Any]:
 
   tensor_size = n * a.itemsize
   bw_gbps = (tensor_size * 2) / result.time_median / 1e9  # read + write = 2
-  ret = {
-      "dtype": dtype.__name__,
-      "tensor_size_bytes": n * a.itemsize,
-      "time_median_ms": result.time_median * 1000,
-      "time_min_ms": result.time_min * 1000,
-      "bandwidth_gbps_median": bw_gbps,
-      "bandwidth_gbps_max": (tensor_size * 2) / result.time_min / 1e9,
-  }
 
   print(f"Tensor size: {tensor_size / 1024**2} MB, time taken (median): {result.time_median * 1000:.4f} ms, bandwidth: {bw_gbps:.2f} GBps")
-  return ret
 
 
 if __name__ == "__main__":

--- a/microbenchmarks/benchmark_hbm.py
+++ b/microbenchmarks/benchmark_hbm.py
@@ -1,0 +1,142 @@
+r"""Benchmark for HBM bandwidth.
+
+Sample usage (on TPU vm):
+  $ python benchmark_hbm.py \
+  --num_elements=16777216 \
+  --matcher="jit_my_copy.*"
+"""
+
+import argparse
+import os
+import re
+from typing import Any
+from benchmark_utils import run_bench
+import jax
+import jax.numpy as jnp
+
+
+def my_copy(a):
+  return a.copy()
+
+
+def get_dtype(dtype: str):
+  if dtype == "bf16":
+    return jnp.bfloat16
+  if dtype == "fp8_e5m2":
+    return jnp.float8_e5m2
+  if dtype == "fp8_e4m3":
+    return jnp.float8_e4m3fn
+  raise ValueError(f"Invalid data type: {dtype}")
+
+
+def main() -> dict[str, Any]:
+  """Benchmark for HBM bandwidth.
+
+  Returns: a dict summarizing the benchmark result.
+  """
+  parser = argparse.ArgumentParser(
+      description="Run HBM bandwidth benchmark."
+  )
+
+  parser.add_argument(
+      "--dtype",
+      type=str,
+      choices=["bf16", "fp8_e5m2", "fp8_e4m3"],
+      default="bf16",
+      help="Data type of the matrix elements.",
+  )
+  parser.add_argument(
+      "--libtpu_args",
+      type=str,
+      required=False,
+      help=(
+          "LIBTPU_INIT_ARGS environment variable, e.g."
+          " '--xla_tpu_scoped_vmem_limit_kib=65536'."
+      ),
+  )
+  parser.add_argument(
+      "--num_elements",
+      type=int,
+      required=True,
+      help="Number of elements in the array.",
+  )
+  parser.add_argument(
+      "--num_iter",
+      type=int,
+      default=100,
+      help="Number of times the matmul kernel will be run.",
+  )
+  parser.add_argument(
+      "--warmup_iter",
+      type=int,
+      default="1",
+      help=(
+          "Number of times the matmul kernel will be run to warm up before the"
+          " acutal timing measurement starts."
+      ),
+  )
+  parser.add_argument(
+      "--log_dir",
+      type=str,
+      default="/tmp/hbm",
+      help="The directory to save the profiler trace to.",
+  )
+  parser.add_argument(
+      "--label",
+      type=str,
+      default="my_func",
+      help=(
+          "A label used to name the function to be benchmarked in the trace"
+          " events."
+      ),
+  )
+  parser.add_argument(
+      "--matcher",
+      type=str,
+      required=False,
+      help=(
+          "A regex-based string matcher to filter the trace evnets eligible for"
+          " benchmarking. This arg would be useful if we want to measure the"
+          " timing of a specific op or XLA module within the function., e.g."
+          " --matcher='fusion' measures the timing of XLA fusion op"
+          " specifically."
+      ),
+  )
+
+  args = parser.parse_args()
+
+  if args.libtpu_args:
+    os.environ["LIBTPU_INIT_ARGS"] = args.libtpu_args
+
+  dtype = get_dtype(args.dtype)
+  n = args.num_elements
+  a = jax.random.normal(jax.random.key(0), (n,)).astype(dtype)
+  compiled = jax.jit(my_copy).lower(a).compile()
+
+  matcher = re.compile(args.matcher) if args.matcher else None
+  result = run_bench(
+      lambda: jax.block_until_ready(compiled(a)),
+      num_iter=args.num_iter,
+      warmup_iter=args.warmup_iter,
+      log_dir=args.log_dir,
+      func_label=args.label,
+      event_matcher=matcher,
+  )
+
+  tensor_size = n * a.itemsize
+  bw_gbps = (tensor_size * 2) / result.time_median / 1e9  # read + write = 2
+  ret = {
+      "dtype": dtype.__name__,
+      "tensor_size_bytes": n * a.itemsize,
+      "time_median_ms": result.time_median * 1000,
+      "time_min_ms": result.time_min * 1000,
+      "bandwidth_gbps_median": bw_gbps,
+      "bandwidth_gbps_max": (tensor_size * 2) / result.time_min / 1e9,
+  }
+
+  print(f"Tensor size: {tensor_size / 1024**2} MB, time taken (median): {result.time_median * 1000:.4f} ms, bandwidth: {bw_gbps:.2f} GBps")
+  return ret
+
+
+if __name__ == "__main__":
+  main()

--- a/microbenchmarks/benchmark_matmul.py
+++ b/microbenchmarks/benchmark_matmul.py
@@ -1,0 +1,154 @@
+r"""Benchmark for matrix multiplication.
+
+Sample usage (on TPU vm):
+  $ python benchmark_matmul.py \
+  --dim 4096 4096 4096 \
+  --libtpu_args=--xla_tpu_scoped_vmem_limit_kib=65536 \
+  --matcher="jit_matmul.*"
+"""
+
+import argparse
+import os
+import re
+from typing import Any
+from benchmark_utils import run_bench
+import jax
+import jax.numpy as jnp
+
+
+def matmul(a, b):
+  return a @ b
+
+
+def get_dtype(dtype: str):
+  if dtype == "bf16":
+    return jnp.bfloat16
+  if dtype == "fp8_e5m2":
+    return jnp.float8_e5m2
+  if dtype == "fp8_e4m3":
+    return jnp.float8_e4m3fn
+  raise ValueError(f"Invalid data type: {dtype}")
+
+
+def main() -> dict[str, Any]:
+  """Benchmark for matrix multiplication.
+
+  Returns: a dict summarizing the benchmark result.
+  """
+  parser = argparse.ArgumentParser(
+      description="Run matrix multiplication benchmark."
+  )
+
+  parser.add_argument(
+      "--dtype",
+      type=str,
+      choices=["bf16", "fp8_e5m2", "fp8_e4m3"],
+      default="bf16",
+      help="Data type of the matrix elements.",
+  )
+  parser.add_argument(
+      "--libtpu_args",
+      type=str,
+      required=False,
+      help=(
+          "LIBTPU_INIT_ARGS environment variable, e.g."
+          " '--xla_tpu_scoped_vmem_limit_kib=65536'."
+      ),
+  )
+  parser.add_argument(
+      "--dim",
+      type=int,
+      required=True,
+      nargs=3,
+      help=(
+          "Dimensions of the two matices to be multiplied. 3 integers, m, n, k"
+          " must be specified, implying (m, n) * (n, k)."
+      ),
+  )
+  parser.add_argument(
+      "--num_iter",
+      type=int,
+      default=100,
+      help="Number of times the matmul kernel will be run.",
+  )
+  parser.add_argument(
+      "--warmup_iter",
+      type=int,
+      default="1",
+      help=(
+          "Number of times the matmul kernel will be run to warm up before the"
+          " acutal timing measurement starts."
+      ),
+  )
+  parser.add_argument(
+      "--log_dir",
+      type=str,
+      default="/tmp/matmul",
+      help="The directory to save the profiler trace to.",
+  )
+  parser.add_argument(
+      "--label",
+      type=str,
+      default="my_func",
+      help=(
+          "A label used to name the function to be benchmarked in the trace"
+          " events."
+      ),
+  )
+  parser.add_argument(
+      "--matcher",
+      type=str,
+      required=False,
+      help=(
+          "A regex-based string matcher to filter the trace evnets eligible for"
+          " benchmarking. This arg would be useful if we want to measure the"
+          " timing of a specific op or XLA module within the function., e.g."
+          " --matcher='fusion' measures the timing of XLA fusion op"
+          " specifically."
+      ),
+  )
+
+  args = parser.parse_args()
+
+  if args.libtpu_args:
+    os.environ["LIBTPU_INIT_ARGS"] = args.libtpu_args
+
+  dtype = get_dtype(args.dtype)
+  m, n, k = args.dim[0], args.dim[1], args.dim[2]
+  a = jax.random.normal(jax.random.key(0), (m, n)).astype(dtype)
+  b = jax.random.normal(jax.random.key(0), (n, k)).astype(dtype)
+
+  compiled = jax.jit(matmul).lower(a, b).compile()
+  matcher = re.compile(args.matcher) if args.matcher else None
+  result = run_bench(
+      lambda: jax.block_until_ready(compiled(a, b)),
+      num_iter=args.num_iter,
+      warmup_iter=args.warmup_iter,
+      log_dir=args.log_dir,
+      func_label=args.label,
+      event_matcher=matcher,
+  )
+
+  # MXU is done in units of bf16.
+  mxu_bytes_per_op = 2
+  # 2 ops (multiple and add)
+  compute_flops = m * n * k * a.itemsize * 2 / mxu_bytes_per_op
+  throughput = compute_flops / result.time_median / 1e12
+
+  ret = {
+      "dtype": dtype.__name__,
+      "matrix_dimensions": (m, n, k),
+      "time_median_ms": result.time_median * 1e3,
+      "tflops_per_sec_median": throughput,
+      "time_min_ms": result.time_min * 1e3,
+      "tflops_per_sec_max": compute_flops / result.time_min / 1e12,
+  }
+  print(
+      f"dtype: {dtype.__name__}, matrix Dimensions: ({m}, {n}, {k}), time taken"
+      f" (median): {result.time_median * 1e3} ms, TFLOPs/sec: {throughput}"
+  )
+  return ret
+
+
+if __name__ == "__main__":
+  main()

--- a/microbenchmarks/benchmark_matmul.py
+++ b/microbenchmarks/benchmark_matmul.py
@@ -30,11 +30,8 @@ def get_dtype(dtype: str):
   raise ValueError(f"Invalid data type: {dtype}")
 
 
-def main() -> dict[str, Any]:
-  """Benchmark for matrix multiplication.
-
-  Returns: a dict summarizing the benchmark result.
-  """
+def main():
+  """Benchmark for matrix multiplication."""
   parser = argparse.ArgumentParser(
       description="Run matrix multiplication benchmark."
   )
@@ -135,19 +132,10 @@ def main() -> dict[str, Any]:
   compute_flops = m * n * k * a.itemsize * 2 / mxu_bytes_per_op
   throughput = compute_flops / result.time_median / 1e12
 
-  ret = {
-      "dtype": dtype.__name__,
-      "matrix_dimensions": (m, n, k),
-      "time_median_ms": result.time_median * 1e3,
-      "tflops_per_sec_median": throughput,
-      "time_min_ms": result.time_min * 1e3,
-      "tflops_per_sec_max": compute_flops / result.time_min / 1e12,
-  }
   print(
       f"dtype: {dtype.__name__}, matrix Dimensions: ({m}, {n}, {k}), time taken"
       f" (median): {result.time_median * 1e3} ms, TFLOPs/sec: {throughput}"
   )
-  return ret
 
 
 if __name__ == "__main__":

--- a/microbenchmarks/benchmark_utils.py
+++ b/microbenchmarks/benchmark_utils.py
@@ -1,0 +1,146 @@
+"""Utilities for benchmarks."""
+
+from dataclasses import dataclass
+import gzip
+import json
+import os
+import pathlib
+import re
+from typing import Any, Callable
+import jax
+import numpy as np
+
+
+@dataclass
+class BenchmarkResult:
+  """The result of a benchmark run.
+
+  Attributes:
+    time_median: the median elapsed time of the benchmark at the event level. By
+      default, the event to be measured is equivalent to the function to be
+      benchmarked, unless an event_matcher is provided.
+    time_min: the minimum elapsed time of the benchmark.
+  """
+
+  time_median: float = 0
+  time_min: float = 0
+
+
+def get_trace(log_dir: str) -> dict[str, Any]:
+  """Extract the trace object from the log directory.
+
+  If multiple profiles exist in the directory, the lastest one will be used.
+
+  Args:
+    log_dir: log directory created by jax.profiler.trace().
+
+  Returns:
+    A trace object in JSON format.
+  """
+  # Navigate to the folder with the latest trace dump to find `trace.json.jz`
+  trace_folders = (
+      pathlib.Path(log_dir).absolute() / "plugins" / "profile"
+  ).iterdir()
+  latest_trace_folder = max(trace_folders, key=os.path.getmtime)
+  trace_jsons = latest_trace_folder.glob("*.trace.json.gz")
+  try:
+    (trace_json,) = trace_jsons
+  except ValueError as value_error:
+    raise ValueError(
+        f"Invalid trace folder: {latest_trace_folder}"
+    ) from value_error
+
+  with gzip.open(trace_json, "rb") as f:
+    trace = json.load(f)
+
+  return trace
+
+
+def get_eligible_events(
+    trace: dict[str, Any],
+    event_matcher: re.Pattern[str],
+) -> list[dict[str, Any]]:
+  """Filter the trace events eligible for benchmarking.
+
+  Args:
+    trace: a trace object in JSON format.
+    event_matcher: a regex-based event name matcher to filter the evnets.
+
+  Returns:
+    A list of events objects in JSON format.
+  """
+  if "traceEvents" not in trace:
+    raise KeyError("Key 'traceEvents' not found in trace.")
+
+  ret = []
+  for e in trace["traceEvents"]:
+    if "name" in e and event_matcher.match(e["name"]):
+      ret.append(e)
+  return ret
+
+
+def get_benchmark_result(events: list[dict[str, Any]]) -> BenchmarkResult:
+  """Derive the benchmark result from the given list of trace events.
+
+  Args:
+    events: a list of trace events.
+
+  Returns:
+    A summary of the benchmark result.
+  """
+  try:
+    durations = [e["dur"] / 1e6 for e in events]
+  except KeyError:
+    print("KeyError: Key 'dur' not found in the event object")
+    raise
+
+  return BenchmarkResult(
+      time_median=np.median(durations),
+      time_min=np.min(durations),
+  )
+
+
+def run_bench(
+    fn: Callable[..., Any],
+    num_iter: int,
+    warmup_iter: int,
+    log_dir: str,
+    func_label: str,
+    event_matcher: re.Pattern[str] = None,
+) -> BenchmarkResult:
+  """Runs a function `num_iter` times to measure the runtime for benchmarking.
+
+  A jax profiler trace is captured in order to measure the timing at the event
+  level within the function.
+
+  Args:
+    fn: the function to be benchmarked.
+    num_iter: number of times `fn` will be run.
+    warmup_iter: number of times `fn` will be run before the acutal timing
+      measurement.
+    log_dir: the directory to save the profiler trace to.
+    func_label: a label to identify the function in the trace events.
+    event_matcher: a regex-based event matcher to filter the evnets eligible for
+      benchmarking. If None, the runtime of the function will be reported.
+
+  Returns:
+    A summary of the benchmark result.
+  """
+  # warm up
+  for _ in range(warmup_iter):
+    fn()
+
+  with jax.profiler.trace(log_dir):
+    for _ in range(num_iter):
+      jax.clear_caches()
+      with jax.profiler.TraceAnnotation(func_label):
+        fn()
+
+  trace = get_trace(log_dir)
+
+  if not event_matcher:
+    event_matcher = re.compile(func_label)
+  events = get_eligible_events(trace, event_matcher)
+  assert len(events) == num_iter
+
+  return get_benchmark_result(events)

--- a/microbenchmarks/requirements.txt
+++ b/microbenchmarks/requirements.txt
@@ -1,0 +1,2 @@
+jax[tpu]
+tensorboard-plugin-profile


### PR DESCRIPTION
Add micro-benchmarks for matmul and HBM bandwidth tests.

TODO: move the code to https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git and add a shell script here pointing to that repo.