### PR TITLE
Update mixtral pytorch batch size with new docker

### DIFF
--- a/training/trillium/Mixtral-8x7B-Pytorch/GCE/README.md
+++ b/training/trillium/Mixtral-8x7B-Pytorch/GCE/README.md
@@ -42,7 +42,7 @@ HF_TOKEN=hf_***
 3. Edit `host.sh` to add the docker image URL if default docker image is not accessible to you.
 ```bash
 # docker image URL to use for the training
-DOCKER_IMAGE=us-central1-docker.pkg.dev/deeplearning-images/reproducibility/pytorch-tpu-mixtral:v0
+DOCKER_IMAGE=us-central1-docker.pkg.dev/deeplearning-images/reproducibility/pytorch-tpu-mixtral:dropping
 ```
 4. Run the training script:
 ```bash
@@ -52,11 +52,11 @@ DOCKER_IMAGE=us-central1-docker.pkg.dev/deeplearning-images/reproducibility/pyto
 ```
 ***** train metrics *****
 [worker :3] ***** train metrics *****
-[worker :3]   epoch                    =      0.0391
-[worker :3]   total_flos               = 216428520GF
-[worker :3]   train_loss               =       8.443
-[worker :3]   train_runtime            =  0:04:23.15
-[worker :3]   train_samples            =       32816
-[worker :3]   train_samples_per_second =       4.864
+[worker :3]   epoch                    =      <num_epochs>
+[worker :3]   total_flos               =      <floating point ops per sec>
+[worker :3]   train_loss               =      <loss>
+[worker :3]   train_runtime            =      <total_runtime>
+[worker :3]   train_samples            =      <global number of samples>
+[worker :3]   train_samples_per_second =      <global number of samples per sec>
 ```
 In addition,  it will copy back the trained model under `output/*`.

--- a/training/trillium/Mixtral-8x7B-Pytorch/GCE/config.json
+++ b/training/trillium/Mixtral-8x7B-Pytorch/GCE/config.json
@@ -15,7 +15,7 @@
     "num_experts_per_tok": 2,
     "num_hidden_layers": 32,
     "num_key_value_heads": 8,
-    "capacity_factor": 1.1,
+    "capacity_factor": 1.25,
     "num_local_experts": 8,
     "output_router_logits": false,
     "rms_norm_eps": 1e-05,

--- a/training/trillium/Mixtral-8x7B-Pytorch/GCE/env.sh
+++ b/training/trillium/Mixtral-8x7B-Pytorch/GCE/env.sh
@@ -10,7 +10,7 @@ XLA_USE_SPMD=1
 MAX_STEPS=20
 SEQ_LENGTH=4096
 
-GLOBAL_BATCH_SIZE=1024
+GLOBAL_BATCH_SIZE=2048
 
 # XLA flags
 LIBTPU_INIT_ARGS=--xla_tpu_enable_flash_attention=false --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true --xla_tpu_scoped_vmem_limit_kib=81920

--- a/training/trillium/Mixtral-8x7B-Pytorch/GCE/host.sh
+++ b/training/trillium/Mixtral-8x7B-Pytorch/GCE/host.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DOCKER_IMAGE=us-central1-docker.pkg.dev/deeplearning-images/reproducibility/pytorch-tpu-mixtral:multipod
+DOCKER_IMAGE=us-central1-docker.pkg.dev/deeplearning-images/reproducibility/pytorch-tpu-mixtral:dropping
 
 worker_id=$(curl -s "http://metadata.google.internal/computeMetadata/v1/instance/attributes/agent-worker-number" -H 'Metadata-Flavor: Google')
 

--- a/training/trillium/Mixtral-8x7B-Pytorch/XPK/config.json
+++ b/training/trillium/Mixtral-8x7B-Pytorch/XPK/config.json
@@ -15,7 +15,7 @@
   "num_experts_per_tok": 2,
   "num_hidden_layers": 32,
   "num_key_value_heads": 8,
-  "capacity_factor": 1.1,
+  "capacity_factor": 1.25,
   "num_local_experts": 8,
   "output_router_logits": false,
   "rms_norm_eps": 1e-05,

--- a/training/trillium/Mixtral-8x7B-Pytorch/XPK/env.sh
+++ b/training/trillium/Mixtral-8x7B-Pytorch/XPK/env.sh
@@ -8,10 +8,10 @@ export NUM_SLICE=1
 export CLUSTER_NAME=xpk-$USER-... # use existing CLUSTER if you have
 
 # Environment variables associated with training config.
-export BATCH_PER_DEVICE=4
+export BATCH_PER_DEVICE=8
 export SEQUENCE_LENGTH=4096
 export MAX_STEP=50
 export WORKLOAD_NAME=${USER}-xpk-${TPU_TYPE}-... # Your workload name. Need to update for different run.
-export BASE_DOCKER_IMAGE=us-central1-docker.pkg.dev/deeplearning-images/reproducibility/pytorch-tpu-mixtral:multipod
+export BASE_DOCKER_IMAGE=us-central1-docker.pkg.dev/deeplearning-images/reproducibility/pytorch-tpu-mixtral:dropping
 export PROFILE_LOG_DIR=... # GCS bucket to store profile in form of gs://...
 export HF_TOKEN=... # Add your own Hugging face token to download model

--- a/training/trillium/Mixtral-8x7B-Pytorch/XPK/train.sh
+++ b/training/trillium/Mixtral-8x7B-Pytorch/XPK/train.sh
@@ -22,7 +22,6 @@ export PROFILE_STEP=3
 export PROFILE_DURATION_MS=100000
 export PROFILE_LOGDIR=${PROFILE_LOG_DIR}
 export XLA_PERSISTENT_CACHE_PATH=/app/xla_cache/
-export TPU_LIBRARY_PATH=/workspace/_libtpu.so
 export NUM_TPU_SLICE=${NUM_SLICE}
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_flash_attention=false --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true --xla_tpu_scoped_vmem_limit_kib=81920"
 
@@ -30,7 +29,7 @@ huggingface-cli login --token=${HF_TOKEN}
 
 # Note --per_device_train_batch_size is the global batch size since we overwrite the dataloader in the HF trainer.
 # --static uses the dropping implementation for MoE.
-python3 /workspace/transformers/examples/pytorch/language-modeling/run_clm.py \
+python3 /workspaces/transformers/examples/pytorch/language-modeling/run_clm.py \
 --dataset_name=wikitext --dataset_config_name=wikitext-103-raw-v1 \
 --per_device_train_batch_size=${GLOBAL_BATCH_SIZE} --do_train --output_dir=test-clm \
 --overwrite_output_dir --config_name=/app/config.json \


### PR DESCRIPTION
This config is able to achieve around 33.5% +- 0.5% MFU on mixtral. 

Test run on XPK: https://cloudlogging.app.goo.gl/UvYWYnwCbDzAwhW18

I didn't run on GCE since there is no GCE capacity to test.

The Dockerfile is at https://github.com/pytorch-tpu/transformers/blob/expert_parallel/Dockerfile