### PR TITLE
Put MaxText installation instructions before tag info

### DIFF
--- a/training/trillium/GPT3-175B-MaxText/bf16/README.md
+++ b/training/trillium/GPT3-175B-MaxText/bf16/README.md
@@ -5,16 +5,15 @@ Please follow this [link](https://github.com/AI-Hypercomputer/tpu-recipes/blob/m
 
 ## Prep for Maxtext 
 
-### Test Env
-Use the MaxText [tpu-recipes-v0.1.0](https://github.com/AI-Hypercomputer/maxtext/releases/tag/tpu-recipes-v0.1.0) tag to run this recipe. This can be done using the following command from your local MaxText directory:
+### Install MaxText and Build Docker Image
+Please follow this [link](https://github.com/AI-Hypercomputer/tpu-recipes/blob/main/training/trillium/MAXTEXT_README.md) to install maxtext and build the docker image. The following variables should be set:
 
+In step 1, use the MaxText [tpu-recipes-v0.1.0](https://github.com/AI-Hypercomputer/maxtext/releases/tag/tpu-recipes-v0.1.0) tag to run this recipe:
 ```
 git checkout tpu-recipes-v0.1.0
 ```
 
-### Install MaxText and Build Docker Image
-Please follow this [link](https://github.com/AI-Hypercomputer/tpu-recipes/blob/main/training/trillium/MAXTEXT_README.md) to install maxtext and build docker image. In step 2, be sure to use the jax-stable-stack image containing JAX 0.4.37:
-
+In step 2, use the jax-stable-stack image containing JAX 0.4.37:
 ```
 BASE_IMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-stable-stack/tpu:jax0.4.37-rev1
 bash docker_build_dependency_image.sh DEVICE=tpu MODE=stable_stack BASEIMAGE=${BASE_IMAGE}

--- a/training/trillium/Llama2-70B-MaxText/README.md
+++ b/training/trillium/Llama2-70B-MaxText/README.md
@@ -5,16 +5,15 @@ Please follow this [link](https://github.com/AI-Hypercomputer/tpu-recipes/blob/m
 
 ## Prep for Maxtext 
 
-### Test Env
-Use the MaxText [tpu-recipes-v0.1.0](https://github.com/AI-Hypercomputer/maxtext/releases/tag/tpu-recipes-v0.1.0) tag to run this recipe. This can be done using the following command from your local MaxText directory:
+### Install MaxText and Build Docker Image
+Please follow this [link](https://github.com/AI-Hypercomputer/tpu-recipes/blob/main/training/trillium/MAXTEXT_README.md) to install maxtext and build the docker image. The following variables should be set:
 
+In step 1, use the MaxText [tpu-recipes-v0.1.0](https://github.com/AI-Hypercomputer/maxtext/releases/tag/tpu-recipes-v0.1.0) tag to run this recipe:
 ```
 git checkout tpu-recipes-v0.1.0
 ```
 
-### Install MaxText and Build Docker Image
-Please follow this [link](https://github.com/AI-Hypercomputer/tpu-recipes/blob/main/training/trillium/MAXTEXT_README.md) to install maxtext and build docker image. In step 2, be sure to use the jax-stable-stack image containing JAX 0.4.37:
-
+In step 2, use the jax-stable-stack image containing JAX 0.4.37:
 ```
 BASE_IMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-stable-stack/tpu:jax0.4.37-rev1
 bash docker_build_dependency_image.sh DEVICE=tpu MODE=stable_stack BASEIMAGE=${BASE_IMAGE}

--- a/training/trillium/Llama3-8B-MaxText/v6e-8/README.md
+++ b/training/trillium/Llama3-8B-MaxText/v6e-8/README.md
@@ -5,16 +5,15 @@ Please follow this [link](https://github.com/AI-Hypercomputer/tpu-recipes/blob/m
 
 ## Prep for Maxtext
 
-### Test Env
-Use the MaxText [tpu-recipes-v0.1.0](https://github.com/AI-Hypercomputer/maxtext/releases/tag/tpu-recipes-v0.1.0) tag to run this recipe. This can be done using the following command from your local MaxText directory:
+### Install MaxText and Build Docker Image
+Please follow this [link](https://github.com/AI-Hypercomputer/tpu-recipes/blob/main/training/trillium/MAXTEXT_README.md) to install maxtext and build the docker image. The following variables should be set:
 
+In step 1, use the MaxText [tpu-recipes-v0.1.0](https://github.com/AI-Hypercomputer/maxtext/releases/tag/tpu-recipes-v0.1.0) tag to run this recipe:
 ```
 git checkout tpu-recipes-v0.1.0
 ```
 
-### Install MaxText and Build Docker Image
-Please follow this [link](https://github.com/AI-Hypercomputer/tpu-recipes/blob/main/training/trillium/MAXTEXT_README.md) to install maxtext and build docker image. In step 2, be sure to use the jax-stable-stack image containing JAX 0.4.37:
-
+In step 2, use the jax-stable-stack image containing JAX 0.4.37:
 ```
 BASE_IMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-stable-stack/tpu:jax0.4.37-rev1
 bash docker_build_dependency_image.sh DEVICE=tpu MODE=stable_stack BASEIMAGE=${BASE_IMAGE}

--- a/training/trillium/Llama3.1-405B-MaxText/README.md
+++ b/training/trillium/Llama3.1-405B-MaxText/README.md
@@ -5,16 +5,15 @@ Please follow this [link](https://github.com/AI-Hypercomputer/tpu-recipes/blob/m
 
 ## Prep for Maxtext
 
-### Test Env
-Use the MaxText [tpu-recipes-v0.1.0](https://github.com/AI-Hypercomputer/maxtext/releases/tag/tpu-recipes-v0.1.0) tag to run this recipe. This can be done using the following command from your local MaxText directory:
+### Install MaxText and Build Docker Image
+Please follow this [link](https://github.com/AI-Hypercomputer/tpu-recipes/blob/main/training/trillium/MAXTEXT_README.md) to install maxtext and build the docker image. The following variables should be set:
 
+In step 1, use the MaxText [tpu-recipes-v0.1.0](https://github.com/AI-Hypercomputer/maxtext/releases/tag/tpu-recipes-v0.1.0) tag to run this recipe:
 ```
 git checkout tpu-recipes-v0.1.0
 ```
 
-### Install MaxText and Build Docker Image
-Please follow this [link](https://github.com/AI-Hypercomputer/tpu-recipes/blob/main/training/trillium/MAXTEXT_README.md) to install maxtext and build docker image. In step 2, be sure to use the jax-stable-stack image containing JAX 0.4.37:
-
+In step 2, use the jax-stable-stack image containing JAX 0.4.37:
 ```
 BASE_IMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-stable-stack/tpu:jax0.4.37-rev1
 bash docker_build_dependency_image.sh DEVICE=tpu MODE=stable_stack BASEIMAGE=${BASE_IMAGE}

--- a/training/trillium/MAXTEXT_README.md
+++ b/training/trillium/MAXTEXT_README.md
@@ -3,7 +3,9 @@
 ```
 git clone https://github.com/google/maxtext.git
 cd maxtext
-git checkout ${MAXTEXT_HASH}
+# Checkout either the commit id or MaxText tag. 
+# Example: `git checkout tpu-recipes-v0.1.0`
+git checkout ${MAXTEXT_COMMIT_ID_OR_TAG}
 ```
 
 2. Run the following commands to build the docker image

--- a/training/trillium/Mistral-7B-MaxText/README.md
+++ b/training/trillium/Mistral-7B-MaxText/README.md
@@ -5,16 +5,15 @@ Please follow this [link](https://github.com/AI-Hypercomputer/tpu-recipes/blob/m
 
 ## Prep for Maxtext
 
-### Test Env
-Use the MaxText [tpu-recipes-v0.1.0](https://github.com/AI-Hypercomputer/maxtext/releases/tag/tpu-recipes-v0.1.0) tag to run this recipe. This can be done using the following command from your local MaxText directory:
+### Install MaxText and Build Docker Image
+Please follow this [link](https://github.com/AI-Hypercomputer/tpu-recipes/blob/main/training/trillium/MAXTEXT_README.md) to install maxtext and build the docker image. The following variables should be set:
 
+In step 1, use the MaxText [tpu-recipes-v0.1.0](https://github.com/AI-Hypercomputer/maxtext/releases/tag/tpu-recipes-v0.1.0) tag to run this recipe:
 ```
 git checkout tpu-recipes-v0.1.0
 ```
 
-### Install MaxText and Build Docker Image
-Please follow this [link](https://github.com/AI-Hypercomputer/tpu-recipes/blob/main/training/trillium/MAXTEXT_README.md) to install maxtext and build docker image. In step 2, be sure to use the jax-stable-stack image containing JAX 0.4.37:
-
+In step 2, use the jax-stable-stack image containing JAX 0.4.37:
 ```
 BASE_IMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-stable-stack/tpu:jax0.4.37-rev1
 bash docker_build_dependency_image.sh DEVICE=tpu MODE=stable_stack BASEIMAGE=${BASE_IMAGE}

--- a/training/trillium/Mixtral-8x7B-MaxText/README.md
+++ b/training/trillium/Mixtral-8x7B-MaxText/README.md
@@ -5,16 +5,15 @@ Please follow this [link](https://github.com/AI-Hypercomputer/tpu-recipes/blob/m
 
 ## Prep for Maxtext 
 
-### Test Env
-Use the MaxText [tpu-recipes-v0.1.0](https://github.com/AI-Hypercomputer/maxtext/releases/tag/tpu-recipes-v0.1.0) tag to run this recipe. This can be done using the following command from your local MaxText directory:
+### Install MaxText and Build Docker Image
+Please follow this [link](https://github.com/AI-Hypercomputer/tpu-recipes/blob/main/training/trillium/MAXTEXT_README.md) to install maxtext and build the docker image. The following variables should be set:
 
+In step 1, use the MaxText [tpu-recipes-v0.1.0](https://github.com/AI-Hypercomputer/maxtext/releases/tag/tpu-recipes-v0.1.0) tag to run this recipe:
 ```
 git checkout tpu-recipes-v0.1.0
 ```
 
-### Install MaxText and Build Docker Image
-Please follow this [link](https://github.com/AI-Hypercomputer/tpu-recipes/blob/main/training/trillium/MAXTEXT_README.md) to install maxtext and build docker image. In step 2, be sure to use the jax-stable-stack image containing JAX 0.4.37:
-
+In step 2, use the jax-stable-stack image containing JAX 0.4.37:
 ```
 BASE_IMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-stable-stack/tpu:jax0.4.37-rev1
 bash docker_build_dependency_image.sh DEVICE=tpu MODE=stable_stack BASEIMAGE=${BASE_IMAGE}


### PR DESCRIPTION
### Notes

* Moving the link to setting up MaxText ahead of the instructions to check out the right tag
    * Made this same change for each of the single-host and multi-host recipes we updated recently
* Made a small update to the `git checkout` command example in the MaxText instructions. @chishuen had a question about this in [PR 43](https://github.com/AI-Hypercomputer/tpu-recipes/pull/43#discussion_r1989776661). So I am trying to make that more clear here