### PR TITLE
Update recent MaxText benchmarks to use JSS 0.5.2

### DIFF
--- a/training/trillium/GPT3-175B-MaxText/bf16/README.md
+++ b/training/trillium/GPT3-175B-MaxText/bf16/README.md
@@ -13,9 +13,9 @@ In step 1, use the MaxText [tpu-recipes-v0.1.0](https://github.com/AI-Hypercompu
 git checkout tpu-recipes-v0.1.0
 ```
 
-In step 2, use the jax-stable-stack image containing JAX 0.4.37:
+In step 2, use the jax-stable-stack image containing JAX 0.5.2:
 ```
-BASE_IMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-stable-stack/tpu:jax0.4.37-rev1
+BASE_IMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-stable-stack/tpu:jax0.5.2-rev1
 bash docker_build_dependency_image.sh DEVICE=tpu MODE=stable_stack BASEIMAGE=${BASE_IMAGE}
 ```
 
@@ -38,7 +38,7 @@ python3 benchmarks/benchmark_runner.py xpk \
 
 From your workload logs, you should start seeing step time logs like the following:
 ```
-completed step: 11, seconds: 16.852, TFLOP/s/device: 392.440, Tokens/s/device: 364.593, total_weights: 1572864, loss: 414.684
+completed step: 15, seconds: 17.182, TFLOP/s/device: 384.891, Tokens/s/device: 357.580, total_weights: 1572864, loss: 388.622
 ```
 
 ### Workload Details

--- a/training/trillium/Llama2-70B-MaxText/README.md
+++ b/training/trillium/Llama2-70B-MaxText/README.md
@@ -13,9 +13,9 @@ In step 1, use the MaxText [tpu-recipes-v0.1.0](https://github.com/AI-Hypercompu
 git checkout tpu-recipes-v0.1.0
 ```
 
-In step 2, use the jax-stable-stack image containing JAX 0.4.37:
+In step 2, use the jax-stable-stack image containing JAX 0.5.2:
 ```
-BASE_IMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-stable-stack/tpu:jax0.4.37-rev1
+BASE_IMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-stable-stack/tpu:jax0.5.2-rev1
 bash docker_build_dependency_image.sh DEVICE=tpu MODE=stable_stack BASEIMAGE=${BASE_IMAGE}
 ```
 
@@ -38,7 +38,7 @@ python3 benchmarks/benchmark_runner.py xpk \
 
 From your workload logs, you should start seeing step time logs like the following:
 ```
-completed step: 10, seconds: 8.799, TFLOP/s/device: 413.814, Tokens/s/device: 930.984, total_weights: 2097152, loss: 3.499
+completed step: 16, seconds: 9.052, TFLOP/s/device: 402.274, Tokens/s/device: 905.021, total_weights: 2097152, loss: 1.104"
 ```
 
 ### Workload Details

--- a/training/trillium/Llama3-8B-MaxText/v6e-8/README.md
+++ b/training/trillium/Llama3-8B-MaxText/v6e-8/README.md
@@ -13,9 +13,9 @@ In step 1, use the MaxText [tpu-recipes-v0.1.0](https://github.com/AI-Hypercompu
 git checkout tpu-recipes-v0.1.0
 ```
 
-In step 2, use the jax-stable-stack image containing JAX 0.4.37:
+In step 2, use the jax-stable-stack image containing JAX 0.5.2:
 ```
-BASE_IMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-stable-stack/tpu:jax0.4.37-rev1
+BASE_IMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-stable-stack/tpu:jax0.5.2-rev1
 bash docker_build_dependency_image.sh DEVICE=tpu MODE=stable_stack BASEIMAGE=${BASE_IMAGE}
 ```
 
@@ -38,7 +38,7 @@ python3 benchmarks/benchmark_runner.py xpk \
 
 From your workload logs, you should start seeing step time logs like the following:
 ```
-completed step: 7, seconds: 3.416, TFLOP/s/device: 416.601, Tokens/s/device: 7193.579, total_weights: 196608, loss: 6.634
+completed step: 6, seconds: 3.517, TFLOP/s/device: 404.636, Tokens/s/device: 6986.975, total_weights: 196608, loss: 7.507
 ```
 If you would like to run on multiple slices of v6e-8, you may modify the `--num_slices` flag.
 

--- a/training/trillium/Llama3.1-405B-MaxText/README.md
+++ b/training/trillium/Llama3.1-405B-MaxText/README.md
@@ -13,9 +13,9 @@ In step 1, use the MaxText [tpu-recipes-v0.1.0](https://github.com/AI-Hypercompu
 git checkout tpu-recipes-v0.1.0
 ```
 
-In step 2, use the jax-stable-stack image containing JAX 0.4.37:
+In step 2, use the jax-stable-stack image containing JAX 0.5.2:
 ```
-BASE_IMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-stable-stack/tpu:jax0.4.37-rev1
+BASE_IMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-stable-stack/tpu:jax0.5.2-rev1
 bash docker_build_dependency_image.sh DEVICE=tpu MODE=stable_stack BASEIMAGE=${BASE_IMAGE}
 ```
 
@@ -38,7 +38,7 @@ python3 benchmarks/benchmark_runner.py xpk \
 
 From your workload logs, you should start seeing step time logs like the following:
 ```
-completed step: 10, seconds: 52.121, TFLOP/s/device: 412.644, Tokens/s/device: 157.172, total_weights: 4194304, loss: 2.336
+completed step: 14, seconds: 54.803, TFLOP/s/device: 392.454, Tokens/s/device: 149.482, total_weights: 4194304, loss: 0.297
 ```
 
 ### Workload Details

--- a/training/trillium/Mistral-7B-MaxText/README.md
+++ b/training/trillium/Mistral-7B-MaxText/README.md
@@ -13,9 +13,9 @@ In step 1, use the MaxText [tpu-recipes-v0.1.0](https://github.com/AI-Hypercompu
 git checkout tpu-recipes-v0.1.0
 ```
 
-In step 2, use the jax-stable-stack image containing JAX 0.4.37:
+In step 2, use the jax-stable-stack image containing JAX 0.5.2:
 ```
-BASE_IMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-stable-stack/tpu:jax0.4.37-rev1
+BASE_IMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-stable-stack/tpu:jax0.5.2-rev1
 bash docker_build_dependency_image.sh DEVICE=tpu MODE=stable_stack BASEIMAGE=${BASE_IMAGE}
 ```
 
@@ -38,13 +38,13 @@ python3 benchmarks/benchmark_runner.py xpk \
 
 From your workload logs, you should start seeing step time logs like the following:
 ```
-completed step: 7, seconds: 6.051, TFLOP/s/device: 451.236, Tokens/s/device: 8123.462, total_weights: 393216, loss: 6.765
+completed step: 6, seconds: 6.320, TFLOP/s/device: 431.981, Tokens/s/device: 7776.813, total_weights: 393216, loss: 7.378
 ```
 If you would like to run on multiple slices of v6e-8, you may modify the `--num_slices` flag.
 
 ### Workload Details
 
-For reference, here are the `llama3_1_8b_8192_no_collective_matmul` workload details as found in `MaxText@tpu-recipes-v0.1.0`:
+For reference, here are the `mistral_7b` workload details as found in `MaxText@tpu-recipes-v0.1.0`:
 
 ```
   MaxTextModel(
@@ -90,4 +90,4 @@ For reference, here are the `llama3_1_8b_8192_no_collective_matmul` workload det
   )
 ```
 
-This equivalent workload code can be found in the [maxtext_trillium_model_configs.py](https://github.com/AI-Hypercomputer/maxtext/blob/tpu-recipes-v0.1.0/benchmarks/maxtext_trillium_model_configs.py#L1189-L1232) file within the MaxText repository.
+This equivalent workload code can be found in the [maxtext_trillium_model_configs.py](https://github.com/AI-Hypercomputer/maxtext/blob/tpu-recipes-v0.1.0/benchmarks/maxtext_trillium_model_configs.py#L1217-L1260) file within the MaxText repository.

--- a/training/trillium/Mixtral-8x7B-MaxText/README.md
+++ b/training/trillium/Mixtral-8x7B-MaxText/README.md
@@ -13,9 +13,9 @@ In step 1, use the MaxText [tpu-recipes-v0.1.0](https://github.com/AI-Hypercompu
 git checkout tpu-recipes-v0.1.0
 ```
 
-In step 2, use the jax-stable-stack image containing JAX 0.4.37:
+In step 2, use the jax-stable-stack image containing JAX 0.5.2:
 ```
-BASE_IMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-stable-stack/tpu:jax0.4.37-rev1
+BASE_IMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-stable-stack/tpu:jax0.5.2-rev1
 bash docker_build_dependency_image.sh DEVICE=tpu MODE=stable_stack BASEIMAGE=${BASE_IMAGE}
 ```
 
@@ -39,7 +39,7 @@ python3 benchmarks/benchmark_runner.py xpk \
 
 From your workload logs, you should start seeing step time logs like the following:
 ```
-completed step: 10, seconds: 13.360, TFLOP/s/device: 305.127, Tokens/s/device: 3679.158, total_weights: 12582912, loss: 10.565
+completed step: 11, seconds: 13.484, TFLOP/s/device: 302.311, Tokens/s/device: 3645.203, total_weights: 12582912, loss: 10.546
 ```
 
 ### Workload Details


### PR DESCRIPTION
### Notes

Use the latest stable stack image for these MaxText recipes.

Note: I was consistently seeing 2-5% worse TFLOPs for these benchmarks. It looks like this perf regression is now also present when using the old stable stack image though. Updating these recipes for now. We are investigating the perf difference separately.

### Tests

Re-ran each of these benchmarks using the JAX stable stack 0.5.2 image. Updated the example log with these runs. We are investigating the perf drop separately.