### PR TITLE
Update MaxText release tag to point to correct link

### DIFF
--- a/training/trillium/GPT3-175B-MaxText/bf16/README.md
+++ b/training/trillium/GPT3-175B-MaxText/bf16/README.md
@@ -8,7 +8,7 @@ Please follow this [link](https://github.com/AI-Hypercomputer/tpu-recipes/blob/m
 ### Install MaxText and Build Docker Image
 Please follow this [link](https://github.com/AI-Hypercomputer/tpu-recipes/blob/main/training/trillium/MAXTEXT_README.md) to install maxtext and build the docker image. The following variables should be set:
 
-In step 1, use the MaxText [tpu-recipes-v0.1.0](https://github.com/AI-Hypercomputer/maxtext/releases/tag/tpu-recipes-v0.1.0) tag to run this recipe:
+In step 1, use the MaxText [tpu-recipes-v0.1.1](https://github.com/AI-Hypercomputer/maxtext/releases/tag/tpu-recipes-v0.1.1) tag to run this recipe:
 ```
 git checkout tpu-recipes-v0.1.1
 ```

--- a/training/trillium/Llama2-70B-MaxText/README.md
+++ b/training/trillium/Llama2-70B-MaxText/README.md
@@ -8,7 +8,7 @@ Please follow this [link](https://github.com/AI-Hypercomputer/tpu-recipes/blob/m
 ### Install MaxText and Build Docker Image
 Please follow this [link](https://github.com/AI-Hypercomputer/tpu-recipes/blob/main/training/trillium/MAXTEXT_README.md) to install maxtext and build the docker image. The following variables should be set:
 
-In step 1, use the MaxText [tpu-recipes-v0.1.0](https://github.com/AI-Hypercomputer/maxtext/releases/tag/tpu-recipes-v0.1.0) tag to run this recipe:
+In step 1, use the MaxText [tpu-recipes-v0.1.1](https://github.com/AI-Hypercomputer/maxtext/releases/tag/tpu-recipes-v0.1.1) tag to run this recipe:
 ```
 git checkout tpu-recipes-v0.1.1
 ```

--- a/training/trillium/Llama3-8B-MaxText/v6e-8/README.md
+++ b/training/trillium/Llama3-8B-MaxText/v6e-8/README.md
@@ -8,7 +8,7 @@ Please follow this [link](https://github.com/AI-Hypercomputer/tpu-recipes/blob/m
 ### Install MaxText and Build Docker Image
 Please follow this [link](https://github.com/AI-Hypercomputer/tpu-recipes/blob/main/training/trillium/MAXTEXT_README.md) to install maxtext and build the docker image. The following variables should be set:
 
-In step 1, use the MaxText [tpu-recipes-v0.1.0](https://github.com/AI-Hypercomputer/maxtext/releases/tag/tpu-recipes-v0.1.0) tag to run this recipe:
+In step 1, use the MaxText [tpu-recipes-v0.1.1](https://github.com/AI-Hypercomputer/maxtext/releases/tag/tpu-recipes-v0.1.1) tag to run this recipe:
 ```
 git checkout tpu-recipes-v0.1.1
 ```

--- a/training/trillium/Llama3.1-405B-MaxText/README.md
+++ b/training/trillium/Llama3.1-405B-MaxText/README.md
@@ -8,7 +8,7 @@ Please follow this [link](https://github.com/AI-Hypercomputer/tpu-recipes/blob/m
 ### Install MaxText and Build Docker Image
 Please follow this [link](https://github.com/AI-Hypercomputer/tpu-recipes/blob/main/training/trillium/MAXTEXT_README.md) to install maxtext and build the docker image. The following variables should be set:
 
-In step 1, use the MaxText [tpu-recipes-v0.1.0](https://github.com/AI-Hypercomputer/maxtext/releases/tag/tpu-recipes-v0.1.0) tag to run this recipe:
+In step 1, use the MaxText [tpu-recipes-v0.1.1](https://github.com/AI-Hypercomputer/maxtext/releases/tag/tpu-recipes-v0.1.1) tag to run this recipe:
 ```
 git checkout tpu-recipes-v0.1.1
 ```

--- a/training/trillium/Llama3.1-70B-MaxText/README.md
+++ b/training/trillium/Llama3.1-70B-MaxText/README.md
@@ -8,7 +8,7 @@ Please follow this [link](https://github.com/AI-Hypercomputer/tpu-recipes/blob/m
 ### Install MaxText and Build Docker Image
 Please follow this [link](https://github.com/AI-Hypercomputer/tpu-recipes/blob/main/training/trillium/MAXTEXT_README.md) to install maxtext and build the docker image. The following variables should be set:
 
-In step 1, use the MaxText [tpu-recipes-v0.1.0](https://github.com/AI-Hypercomputer/maxtext/releases/tag/tpu-recipes-v0.1.0) tag to run this recipe:
+In step 1, use the MaxText [tpu-recipes-v0.1.1](https://github.com/AI-Hypercomputer/maxtext/releases/tag/tpu-recipes-v0.1.1) tag to run this recipe:
 ```
 git checkout tpu-recipes-v0.1.1
 ```

--- a/training/trillium/Llama3.1-70B-MaxText/llama3-1-70B-1xv6e-256.sh
+++ b/training/trillium/Llama3.1-70B-MaxText/llama3-1-70B-1xv6e-256.sh
@@ -1,2 +1,11 @@
-python3 -m benchmarks.benchmark_runner xpk --project=$PROJECT --zone=$ZONE --device_type=v6e-256 --num_slices=1  --cluster_name=${CLUSTER_NAME} --base_output_directory=${OUTPUT_DIR} \
---model_name="llama3_1_70b_8192" --base_docker_image maxtext_base_image
+# Run this command from the MaxText root directory using the setup described in the README.
+python3 -m benchmarks.benchmark_runner xpk \
+    --project=$PROJECT \
+    --zone=$ZONE \
+    --device_type=v6e-256 \
+    --num_slices=1  \
+    --cluster_name=${CLUSTER_NAME} \
+    --base_output_directory=${OUTPUT_DIR} \
+    --model_name="llama3_1_70b_8192" \
+    --base_docker_image=maxtext_base_image
+    

--- a/training/trillium/Mistral-7B-MaxText/README.md
+++ b/training/trillium/Mistral-7B-MaxText/README.md
@@ -8,7 +8,7 @@ Please follow this [link](https://github.com/AI-Hypercomputer/tpu-recipes/blob/m
 ### Install MaxText and Build Docker Image
 Please follow this [link](https://github.com/AI-Hypercomputer/tpu-recipes/blob/main/training/trillium/MAXTEXT_README.md) to install maxtext and build the docker image. The following variables should be set:
 
-In step 1, use the MaxText [tpu-recipes-v0.1.0](https://github.com/AI-Hypercomputer/maxtext/releases/tag/tpu-recipes-v0.1.0) tag to run this recipe:
+In step 1, use the MaxText [tpu-recipes-v0.1.1](https://github.com/AI-Hypercomputer/maxtext/releases/tag/tpu-recipes-v0.1.1) tag to run this recipe:
 ```
 git checkout tpu-recipes-v0.1.1
 ```

--- a/training/trillium/Mixtral-8x7B-MaxText/README.md
+++ b/training/trillium/Mixtral-8x7B-MaxText/README.md
@@ -8,7 +8,7 @@ Please follow this [link](https://github.com/AI-Hypercomputer/tpu-recipes/blob/m
 ### Install MaxText and Build Docker Image
 Please follow this [link](https://github.com/AI-Hypercomputer/tpu-recipes/blob/main/training/trillium/MAXTEXT_README.md) to install maxtext and build the docker image. The following variables should be set:
 
-In step 1, use the MaxText [tpu-recipes-v0.1.0](https://github.com/AI-Hypercomputer/maxtext/releases/tag/tpu-recipes-v0.1.0) tag to run this recipe:
+In step 1, use the MaxText [tpu-recipes-v0.1.1](https://github.com/AI-Hypercomputer/maxtext/releases/tag/tpu-recipes-v0.1.1) tag to run this recipe:
 ```
 git checkout tpu-recipes-v0.1.1
 ```


### PR DESCRIPTION
* Update the `tpu-recipes` release tag to point to the right place. The `git checkout` command was updated to the right tag previously, but the link was missed.
    * Fixes b/410464007
* Minor reformatting for the Llama3.1-70B command to match the other commands. Tested this command and the workload kicked off properly