### PR TITLE
Add recommendation to run recipes from a TPU VM

### DIFF
--- a/training/trillium/MAXTEXT_README.md
+++ b/training/trillium/MAXTEXT_README.md
@@ -1,4 +1,8 @@
 # Prep for Maxtext workloads on GKE
+
+> **_NOTE:_** We recommend running these instructions and kicking off your recipe 
+workloads from a TPU VM.
+
 1. Clone [Maxtext](https://github.com/google/maxtext) repo and move to its directory
 ```shell
 git clone https://github.com/google/maxtext.git

--- a/training/trillium/XPK_README.md
+++ b/training/trillium/XPK_README.md
@@ -1,4 +1,8 @@
 ## Initialization
+
+> **_NOTE:_** We recommend running these instructions and kicking off your recipe 
+workloads from a TPU VM.
+
 1. Run the following commands to initialize the project and zone.
 ```shell
 export PROJECT=#<your_project_id>


### PR DESCRIPTION
Add recommendation to run XPK/MaxText installation and tpu-recipes from a TPU VM. This is also how we recommend running them at Google.

The setup/installation is less clear when running from a Mac.