### PR TITLE
Update per_device_batch_size for MaxText Llama3.1-70B and Llama2-70B

### DIFF
--- a/training/trillium/Llama2-70B-MaxText/README.md
+++ b/training/trillium/Llama2-70B-MaxText/README.md
@@ -50,7 +50,7 @@ MaxTextModel(
     model_name="llama2-70b-4096-sc",
     model_type="llama2-70b",
     tuning_params={
-        "per_device_batch_size": 2,
+        "per_device_batch_size": 3,
         "ici_fsdp_parallelism": 1,
         "ici_fsdp_transpose_parallelism": -1,
         "ici_tensor_parallelism": 1,

--- a/training/trillium/Llama3.1-70B-MaxText/README.md
+++ b/training/trillium/Llama3.1-70B-MaxText/README.md
@@ -47,11 +47,11 @@ If you would like to run on multiple slices of v6e-256, you may modify the `--nu
 For reference, here are the `llama3_1_70b_8192` workload details as found in `MaxText@tpu-recipes-v0.1.2`:
 
 ```
-  MaxTextModel(
+MaxTextModel(
     model_name="llama3_1-70b-8192",
     model_type="llama3.1-70b",
     tuning_params={
-        "per_device_batch_size": 4,
+        "per_device_batch_size": 5,
         "ici_fsdp_parallelism": -1,
         "remat_policy": "custom",
         "decoder_layer_input": "offload",
@@ -87,4 +87,4 @@ For reference, here are the `llama3_1_70b_8192` workload details as found in `Ma
   )
 ```
 
-This equivalent workload code can be found in the [maxtext_trillium_model_configs.py](https://github.com/AI-Hypercomputer/maxtext/blob/243b25e480f7550a0c389fa95cd3adcc716fe0df/benchmarks/maxtext_trillium_model_configs.py) file within the MaxText repository.
+This equivalent workload code can be found in the [maxtext_trillium_model_configs.py](https://github.com/AI-Hypercomputer/maxtext/blob/tpu-recipes-v0.1.2/benchmarks/maxtext_trillium_model_configs.py) file within the MaxText repository.


### PR DESCRIPTION
* Updating the tpu-recipe example configs to the correct values for Llama3.1-70B and LLama2-70B. We updated the `per_device_batch_size` for both of these
* Also updated the Llama3.1-70B workload link to use the release tag

No workload changes, just updating the config to match what is actually running