### PR TITLE
Update recommended Python version to 3.12 for recent recipes

### DIFF
--- a/training/MAXTEXT_README.md
+++ b/training/MAXTEXT_README.md
@@ -1,7 +1,8 @@
 # Prep for MaxText workloads on GKE
 
 > **_NOTE:_** We recommend running these instructions and kicking off your recipe 
-workloads from a VM in GCP using Python 3.10.
+workloads from a VM in GCP using Python 3.12 for JAX >= 0.7.0, or Python 3.10 for
+JAX < 0.7.0.
 
 1. Clone [MaxText](https://github.com/google/maxtext) repo and move to its directory
 ```shell

--- a/training/XPK_README.md
+++ b/training/XPK_README.md
@@ -1,7 +1,8 @@
 ## Initialization
 
 > **_NOTE:_** We recommend running these instructions and kicking off your recipe 
-workloads from a VM in GCP using Python 3.10.
+workloads from a VM in GCP using Python 3.12 for JAX >= 0.7.0, or Python 3.10 for
+JAX < 0.7.0.
 
 1. Run the following commands to initialize the project and zone.
 ```shell


### PR DESCRIPTION
MaxText started using Python 3.12 for JAX >= 0.7.0 (JAX stopped supporting Python 3.10 with this version). Updating these instructions to reflect that change.

Keeping 3.10 as the recommended version for earlier recipes to keep the dependencies consistent to what they were at that time.