### PR TITLE
Update XPK_README.md to use specific xpk commit

### DIFF
--- a/training/XPK_README.md
+++ b/training/XPK_README.md
@@ -26,6 +26,7 @@ git clone https://github.com/google/xpk.git
 
 ```shell
 cd xpk # Should be equivalent to cd ~/xpk
+git checkout v0.14.3
 ```
 
 > **_NOTE:_** If you use a virtual environment in the 


### PR DESCRIPTION
Update XPK checkout instructions to use a specific XPK commit. This is in response to a [recent XPK update](google.com/url?sa=j&url=https%3A%2F%2Fgithub.com%2FAI-Hypercomputer%2Fxpk%2Fcommit%2F68dd6a6cbe38da5db8eb64786f3568b567998a73%23diff-353ae9c33b9bb0f0e427fc57dc16c0b8fc4009a1de5d7c8ea747030f99191ad0&uct=1755810666&usg=t3cdORRn4SHBsYgD7RED-LoKNFw.&opi=73833047&source=chat) that removes `xpk.py`.