### PR TITLE
Avoid publishing port when using host network mode

### DIFF
--- a/inference/trillium/vLLM/Llama3.1/README.md
+++ b/inference/trillium/vLLM/Llama3.1/README.md
@@ -89,7 +89,6 @@ export DOCKER_URI=vllm/vllm-tpu:latest
 sudo docker run -it --rm --name $USER-vllm --privileged --net=host \
     -v /dev/shm:/dev/shm \
     --shm-size 150gb \
-    -p 8000:8000 \
     --entrypoint /bin/bash ${DOCKER_URI}
 ```
 

--- a/inference/trillium/vLLM/Llama3.3/README.md
+++ b/inference/trillium/vLLM/Llama3.3/README.md
@@ -93,7 +93,6 @@ To use the latest nightly built image that has more recent features/improvements
 sudo docker run -it --rm --name $USER-vllm --privileged --net=host \
     -v /dev/shm:/dev/shm \
     --shm-size 150gb \
-    -p 8000:8000 \
     --entrypoint /bin/bash ${DOCKER_URI}
 ```
 

--- a/inference/trillium/vLLM/Qwen2.5-32B/README.md
+++ b/inference/trillium/vLLM/Qwen2.5-32B/README.md
@@ -42,7 +42,7 @@ export DOCKER_URI=vllm/vllm-tpu:latest
 ## Step 4: Run the docker container in the TPU instance
 
 ```bash
-sudo docker run -t --rm --name $USER-vllm --privileged --net=host -v /dev/shm:/dev/shm --shm-size 10gb -p 8000:8000 --entrypoint /bin/bash -it ${DOCKER_URI}
+sudo docker run -t --rm --name $USER-vllm --privileged --net=host -v /dev/shm:/dev/shm --shm-size 10gb --entrypoint /bin/bash -it ${DOCKER_URI}
 ```
 
 ## Step 5: Set up env variables

--- a/inference/trillium/vLLM/Qwen2.5-VL/README.md
+++ b/inference/trillium/vLLM/Qwen2.5-VL/README.md
@@ -87,7 +87,6 @@ export DOCKER_URI=vllm/vllm-tpu:latest
 sudo docker run -it --rm --name $USER-vllm --privileged --net=host \
     -v /dev/shm:/dev/shm \
     --shm-size 17gb \
-    -p 8000:8000 \
     --entrypoint /bin/bash ${DOCKER_URI}
 ```
 

--- a/inference/trillium/vLLM/Qwen3/README.md
+++ b/inference/trillium/vLLM/Qwen3/README.md
@@ -78,7 +78,6 @@ export DOCKER_URI=vllm/vllm-tpu:latest
 sudo docker run -it --rm --name $USER-vllm --privileged --net=host \
     -v /dev/shm:/dev/shm \
     --shm-size 100gb \
-    -p 8000:8000 \
     --entrypoint /bin/bash ${DOCKER_URI}
 ```
 


### PR DESCRIPTION
When using network host mode `--net=host`, the port opened by the process is accessible on the host directly, and the port-publish `-p 8000:8000` request is ignored.

> `WARNING: Published ports are discarded when using host network mode`

Remove these port-publish CLI options so the recipe looks more professional.

No behavior change is introduced by this PR.