### PR TITLE
Config fixes for gpt-oss ironwood recipe

### DIFF
--- a/inference/ironwood/vLLM/GPT-OSS/README.md
+++ b/inference/ironwood/vLLM/GPT-OSS/README.md
@@ -207,7 +207,7 @@ create a node pool with a single TPU v7 node in 2x2x1 configuration.
             cloud.google.com/gke-tpu-topology: 2x2x1
           containers:
           - name: vllm-tpu
-            image: vllm/vllm-tpu:nightly-ironwood  # Can be replaced with vllm/vllm-tpu:ironwood once mxfp4 quantization is added to it.
+            image: vllm/vllm-tpu:nightly-ironwood-20251217-baf570b-0cd5353  # Can be replaced with vllm/vllm-tpu:ironwood once mxfp4 quantization is added to it.
             command: ["python3", "-m", "vllm.entrypoints.openai.api_server"]
             args:
             - --host=0.0.0.0


### PR DESCRIPTION
Adding config changes for Ironwood recipe. For now we would need to use the nightly-ironwood build for the recipe since mxfp4 quantization support is still not in vllm/vllm-tpu:ironwood image.