### PR TITLE
Update jax and libtpu readme pinning to use MaxText's docker image build script

### DIFF
--- a/training/ironwood/deepseek3-671b/4k-bf16-tpu7x-4x4x8/xpk/README.md
+++ b/training/ironwood/deepseek3-671b/4k-bf16-tpu7x-4x4x8/xpk/README.md
@@ -203,15 +203,13 @@ if [[ "$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_i
 # Clone MaxText Repository and Checkout Recipe Branch
 git clone https://github.com/AI-Hypercomputer/maxtext.git
 cd maxtext
-git checkout maxtext-tutorial-v1.4.0
-
-# Custom Jax and LibTPU wheels
-pip download libtpu==0.0.32.dev20251215+nightly -f"https://storage.googleapis.com/jax-releases/libtpu_releases.html"
-
-pip download --pre jax==0.8.2.dev20251215 jaxlib==0.8.2.dev20251215 --index https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/
+git checkout maxtext-tutorial-v1.5.0
 
 # Build and upload the docker image
-bash dependencies/scripts/docker_build_dependency_image.sh MODE=custom_wheels
+bash dependencies/scripts/docker_build_dependency_image.sh \
+  MODE=nightly \
+  JAX_VERSION=0.8.2.dev20251215 \
+  LIBTPU_VERSION=0.0.32.dev20251215+nightly
 bash dependencies/scripts/docker_upload_runner.sh CLOUD_IMAGE_NAME=${CLOUD_IMAGE_NAME}
 
 # Deactivate the virtual environment

--- a/training/ironwood/deepseek3-671b/4k-bf16-tpu7x-4x8x8/xpk/README.md
+++ b/training/ironwood/deepseek3-671b/4k-bf16-tpu7x-4x8x8/xpk/README.md
@@ -203,15 +203,13 @@ if [[ "$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_i
 # Clone MaxText Repository and Checkout Recipe Branch
 git clone https://github.com/AI-Hypercomputer/maxtext.git
 cd maxtext
-git checkout maxtext-tutorial-v1.4.0
-
-# Custom Jax and LibTPU wheels
-pip download libtpu==0.0.32.dev20251215+nightly -f"https://storage.googleapis.com/jax-releases/libtpu_releases.html"
-
-pip download --pre jax==0.8.2.dev20251215 jaxlib==0.8.2.dev20251215 --index https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/
+git checkout maxtext-tutorial-v1.5.0
 
 # Build and upload the docker image
-bash dependencies/scripts/docker_build_dependency_image.sh MODE=custom_wheels
+bash dependencies/scripts/docker_build_dependency_image.sh \
+  MODE=nightly \
+  JAX_VERSION=0.8.2.dev20251215 \
+  LIBTPU_VERSION=0.0.32.dev20251215+nightly
 bash dependencies/scripts/docker_upload_runner.sh CLOUD_IMAGE_NAME=${CLOUD_IMAGE_NAME}
 
 # Deactivate the virtual environment

--- a/training/ironwood/deepseek3-671b/4k-fp8-tpu7x-4x4x8/README.md
+++ b/training/ironwood/deepseek3-671b/4k-fp8-tpu7x-4x4x8/README.md
@@ -202,15 +202,13 @@ if [[ "$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_i
 # Clone MaxText Repository and Checkout Recipe Branch
 git clone https://github.com/AI-Hypercomputer/maxtext.git
 cd maxtext
-git checkout maxtext-tutorial-v1.3.0
-
-# Custom Jax and LibTPU wheels
-pip download libtpu==0.0.31.dev20251119+nightly -f"https://storage.googleapis.com/jax-releases/libtpu_releases.html"
-
-pip download --pre jax==0.8.1 jaxlib==0.8.1 --index https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/
+git checkout maxtext-tutorial-v1.5.0
 
 # Build and upload the docker image
-bash dependencies/scripts/docker_build_dependency_image.sh MODE=custom_wheels
+bash dependencies/scripts/docker_build_dependency_image.sh \
+  MODE=nightly \
+  JAX_VERSION=0.8.1 \
+  LIBTPU_VERSION=0.0.31.dev20251119+nightly
 bash dependencies/scripts/docker_upload_runner.sh CLOUD_IMAGE_NAME=${CLOUD_IMAGE_NAME}
 
 # Deactivate the virtual environment

--- a/training/ironwood/deepseek3-671b/4k-fp8-tpu7x-4x8x8/xpk/README.md
+++ b/training/ironwood/deepseek3-671b/4k-fp8-tpu7x-4x8x8/xpk/README.md
@@ -204,15 +204,13 @@ if [[ "$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_i
 # Clone MaxText Repository and Checkout Recipe Branch
 git clone https://github.com/AI-Hypercomputer/maxtext.git
 cd maxtext
-git checkout maxtext-tutorial-v1.4.0
-
-# Custom Jax and LibTPU wheels
-pip download libtpu==0.0.32.dev20251215+nightly -f"https://storage.googleapis.com/jax-releases/libtpu_releases.html"
-
-pip download --pre jax==0.8.2.dev20251215 jaxlib==0.8.2.dev20251215 --index https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/
+git checkout maxtext-tutorial-v1.5.0
 
 # Build and upload the docker image
-bash dependencies/scripts/docker_build_dependency_image.sh MODE=custom_wheels
+bash dependencies/scripts/docker_build_dependency_image.sh \
+  MODE=nightly \
+  JAX_VERSION=0.8.2.dev20251215 \
+  LIBTPU_VERSION=0.0.32.dev20251215+nightly
 bash dependencies/scripts/docker_upload_runner.sh CLOUD_IMAGE_NAME=${CLOUD_IMAGE_NAME}
 
 # Deactivate the virtual environment

--- a/training/ironwood/gpt-oss-120b/8k-bf16-tpu7x-4x4x4/xpk/README.md
+++ b/training/ironwood/gpt-oss-120b/8k-bf16-tpu7x-4x4x4/xpk/README.md
@@ -203,15 +203,13 @@ if [[ "$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_i
 # Clone MaxText Repository and Checkout Recipe Branch
 git clone https://github.com/AI-Hypercomputer/maxtext.git
 cd maxtext
-git checkout maxtext-tutorial-v1.4.0
-
-# Custom Jax and LibTPU wheels
-pip download libtpu==0.0.32.dev20251215+nightly -f"https://storage.googleapis.com/jax-releases/libtpu_releases.html"
-
-pip download --pre jax==0.8.2.dev20251215 jaxlib==0.8.2.dev20251215 --index https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/
+git checkout maxtext-tutorial-v1.5.0
 
 # Build and upload the docker image
-bash dependencies/scripts/docker_build_dependency_image.sh MODE=custom_wheels
+bash dependencies/scripts/docker_build_dependency_image.sh \
+  MODE=nightly \
+  JAX_VERSION=0.8.2.dev20251215 \
+  LIBTPU_VERSION=0.0.32.dev20251215+nightly
 bash dependencies/scripts/docker_upload_runner.sh CLOUD_IMAGE_NAME=${CLOUD_IMAGE_NAME}
 
 # Deactivate the virtual environment

--- a/training/ironwood/gpt-oss-120b/8k-bf16-tpu7x-4x8x8/xpk/README.md
+++ b/training/ironwood/gpt-oss-120b/8k-bf16-tpu7x-4x8x8/xpk/README.md
@@ -203,15 +203,13 @@ if [[ "$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_i
 # Clone MaxText Repository and Checkout Recipe Branch
 git clone https://github.com/AI-Hypercomputer/maxtext.git
 cd maxtext
-git checkout maxtext-tutorial-v1.4.0
-
-# Custom Jax and LibTPU wheels
-pip download libtpu==0.0.32.dev20251215+nightly -f"https://storage.googleapis.com/jax-releases/libtpu_releases.html"
-
-pip download --pre jax==0.8.2.dev20251215 jaxlib==0.8.2.dev20251215 --index https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/
+git checkout maxtext-tutorial-v1.5.0
 
 # Build and upload the docker image
-bash dependencies/scripts/docker_build_dependency_image.sh MODE=custom_wheels
+bash dependencies/scripts/docker_build_dependency_image.sh \
+  MODE=nightly \
+  JAX_VERSION=0.8.2.dev20251215 \
+  LIBTPU_VERSION=0.0.32.dev20251215+nightly
 bash dependencies/scripts/docker_upload_runner.sh CLOUD_IMAGE_NAME=${CLOUD_IMAGE_NAME}
 
 # Deactivate the virtual environment

--- a/training/ironwood/llama3.1-405b/8k-bf16-tpu7x-4x8x8/README.md
+++ b/training/ironwood/llama3.1-405b/8k-bf16-tpu7x-4x8x8/README.md
@@ -203,15 +203,13 @@ if [[ "$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_i
 # Clone MaxText Repository and Checkout Recipe Branch
 git clone https://github.com/AI-Hypercomputer/maxtext.git
 cd maxtext
-git checkout maxtext-tutorial-v1.4.0
-
-# Custom Jax and LibTPU wheels
-pip download libtpu==0.0.33.dev20251218+nightly -f"https://storage.googleapis.com/jax-releases/libtpu_releases.html"
-
-pip download --pre jax==0.8.2 jaxlib==0.8.2 --index https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/
+git checkout maxtext-tutorial-v1.5.0
 
 # Build and upload the docker image
-bash dependencies/scripts/docker_build_dependency_image.sh MODE=custom_wheels
+bash dependencies/scripts/docker_build_dependency_image.sh \
+  MODE=nightly \
+  JAX_VERSION=0.8.2 \
+  LIBTPU_VERSION=0.0.33.dev20251218+nightly
 bash dependencies/scripts/docker_upload_runner.sh CLOUD_IMAGE_NAME=${CLOUD_IMAGE_NAME}
 
 # Deactivate the virtual environment

--- a/training/ironwood/llama3.1-405b/8k-fp8-tpu7x-4x8x8/README.md
+++ b/training/ironwood/llama3.1-405b/8k-fp8-tpu7x-4x8x8/README.md
@@ -204,15 +204,13 @@ if [[ "$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_i
 # Clone MaxText Repository and Checkout Recipe Branch
 git clone https://github.com/AI-Hypercomputer/maxtext.git
 cd maxtext
-git checkout maxtext-tutorial-v1.4.0
-
-# Custom Jax and LibTPU wheels
-pip download libtpu==0.0.33.dev20251219+nightly -f"https://storage.googleapis.com/jax-releases/libtpu_releases.html"
-
-pip download --pre jax==0.8.3.dev20251219 jaxlib==0.8.3.dev20251219 --index https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/
+git checkout maxtext-tutorial-v1.5.0
 
 # Build and upload the docker image
-bash dependencies/scripts/docker_build_dependency_image.sh MODE=custom_wheels
+bash dependencies/scripts/docker_build_dependency_image.sh \
+  MODE=nightly \
+  JAX_VERSION=0.8.3.dev20251219 \
+  LIBTPU_VERSION=0.0.33.dev20251219+nightly
 bash dependencies/scripts/docker_upload_runner.sh CLOUD_IMAGE_NAME=${CLOUD_IMAGE_NAME}
 
 # Deactivate the virtual environment

--- a/training/ironwood/llama3.1-70b/128k-bf16-tpu7x-4x8x8/xpk/README.md
+++ b/training/ironwood/llama3.1-70b/128k-bf16-tpu7x-4x8x8/xpk/README.md
@@ -203,15 +203,13 @@ if [[ "$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_i
 # Clone MaxText Repository and Checkout Recipe Branch
 git clone https://github.com/AI-Hypercomputer/maxtext.git
 cd maxtext
-git checkout maxtext-tutorial-v1.4.0
-
-# Custom Jax and LibTPU wheels
-pip download libtpu==0.0.32.dev20251215+nightly -f"https://storage.googleapis.com/jax-releases/libtpu_releases.html"
-
-pip download --pre jax==0.8.2.dev20251215 jaxlib==0.8.2.dev20251215 --index https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/
+git checkout maxtext-tutorial-v1.5.0
 
 # Build and upload the docker image
-bash dependencies/scripts/docker_build_dependency_image.sh MODE=custom_wheels
+bash dependencies/scripts/docker_build_dependency_image.sh \
+  MODE=nightly \
+  JAX_VERSION=0.8.2.dev20251215 \
+  LIBTPU_VERSION=0.0.32.dev20251215+nightly
 bash dependencies/scripts/docker_upload_runner.sh CLOUD_IMAGE_NAME=${CLOUD_IMAGE_NAME}
 
 # Deactivate the virtual environment

--- a/training/ironwood/llama3.1-70b/128k-fp8-tpu7x-4x8x8/README.md
+++ b/training/ironwood/llama3.1-70b/128k-fp8-tpu7x-4x8x8/README.md
@@ -202,15 +202,13 @@ if [[ "$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_i
 # Clone MaxText Repository and Checkout Recipe Branch
 git clone https://github.com/AI-Hypercomputer/maxtext.git
 cd maxtext
-git checkout maxtext-tutorial-v1.3.0
-
-# Custom Jax and LibTPU wheels
-pip download libtpu==0.0.31.dev20251119+nightly -f"https://storage.googleapis.com/jax-releases/libtpu_releases.html"
-
-pip download --pre jax==0.8.1 jaxlib==0.8.1 --index https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/
+git checkout maxtext-tutorial-v1.5.0
 
 # Build and upload the docker image
-bash dependencies/scripts/docker_build_dependency_image.sh MODE=custom_wheels
+bash dependencies/scripts/docker_build_dependency_image.sh \
+  MODE=nightly \
+  JAX_VERSION=0.8.1 \
+  LIBTPU_VERSION=0.0.31.dev20251119+nightly
 bash dependencies/scripts/docker_upload_runner.sh CLOUD_IMAGE_NAME=${CLOUD_IMAGE_NAME}
 
 # Deactivate the virtual environment

--- a/training/ironwood/llama3.1-70b/8k-bf16-tpu7x-4x4x4/xpk/README.md
+++ b/training/ironwood/llama3.1-70b/8k-bf16-tpu7x-4x4x4/xpk/README.md
@@ -203,15 +203,13 @@ if [[ "$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_i
 # Clone MaxText Repository and Checkout Recipe Branch
 git clone https://github.com/AI-Hypercomputer/maxtext.git
 cd maxtext
-git checkout maxtext-tutorial-v1.4.0
-
-# Custom Jax and LibTPU wheels
-pip download libtpu==0.0.32.dev20251215+nightly -f"https://storage.googleapis.com/jax-releases/libtpu_releases.html"
-
-pip download --pre jax==0.8.2.dev20251215 jaxlib==0.8.2.dev20251215 --index https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/
+git checkout maxtext-tutorial-v1.5.0
 
 # Build and upload the docker image
-bash dependencies/scripts/docker_build_dependency_image.sh MODE=custom_wheels
+bash dependencies/scripts/docker_build_dependency_image.sh \
+  MODE=nightly \
+  JAX_VERSION=0.8.2.dev20251215 \
+  LIBTPU_VERSION=0.0.32.dev20251215+nightly
 bash dependencies/scripts/docker_upload_runner.sh CLOUD_IMAGE_NAME=${CLOUD_IMAGE_NAME}
 
 # Deactivate the virtual environment

--- a/training/ironwood/llama3.1-70b/8k-bf16-tpu7x-4x8x8/xpk/README.md
+++ b/training/ironwood/llama3.1-70b/8k-bf16-tpu7x-4x8x8/xpk/README.md
@@ -203,15 +203,13 @@ if [[ "$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_i
 # Clone MaxText Repository and Checkout Recipe Branch
 git clone https://github.com/AI-Hypercomputer/maxtext.git
 cd maxtext
-git checkout maxtext-tutorial-v1.4.0
-
-# Custom Jax and LibTPU wheels
-pip download libtpu==0.0.32.dev20251215+nightly -f"https://storage.googleapis.com/jax-releases/libtpu_releases.html"
-
-pip download --pre jax==0.8.2.dev20251215 jaxlib==0.8.2.dev20251215 --index https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/
+git checkout maxtext-tutorial-v1.5.0
 
 # Build and upload the docker image
-bash dependencies/scripts/docker_build_dependency_image.sh MODE=custom_wheels
+bash dependencies/scripts/docker_build_dependency_image.sh \
+  MODE=nightly \
+  JAX_VERSION=0.8.2.dev20251215 \
+  LIBTPU_VERSION=0.0.32.dev20251215+nightly
 bash dependencies/scripts/docker_upload_runner.sh CLOUD_IMAGE_NAME=${CLOUD_IMAGE_NAME}
 
 # Deactivate the virtual environment

--- a/training/ironwood/llama3.1-70b/8k-fp8-tpu7x-4x4x4/xpk/README.md
+++ b/training/ironwood/llama3.1-70b/8k-fp8-tpu7x-4x4x4/xpk/README.md
@@ -203,15 +203,13 @@ if [[ "$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_i
 # Clone MaxText Repository and Checkout Recipe Branch
 git clone https://github.com/AI-Hypercomputer/maxtext.git
 cd maxtext
-git checkout maxtext-tutorial-v1.4.0
-
-# Custom Jax and LibTPU wheels
-pip download libtpu==0.0.33.dev20251219+nightly -f"https://storage.googleapis.com/jax-releases/libtpu_releases.html"
-
-pip download --pre jax==0.8.3.dev20251219 jaxlib==0.8.3.dev20251219 --index https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/
+git checkout maxtext-tutorial-v1.5.0
 
 # Build and upload the docker image
-bash dependencies/scripts/docker_build_dependency_image.sh MODE=custom_wheels
+bash dependencies/scripts/docker_build_dependency_image.sh \
+  MODE=nightly \
+  JAX_VERSION=0.8.3.dev20251219 \
+  LIBTPU_VERSION=0.0.33.dev20251219+nightly
 bash dependencies/scripts/docker_upload_runner.sh CLOUD_IMAGE_NAME=${CLOUD_IMAGE_NAME}
 
 # Deactivate the virtual environment

--- a/training/ironwood/llama3.1-70b/8k-fp8-tpu7x-4x8x8/README.md
+++ b/training/ironwood/llama3.1-70b/8k-fp8-tpu7x-4x8x8/README.md
@@ -203,15 +203,13 @@ if [[ "$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_i
 # Clone MaxText Repository and Checkout Recipe Branch
 git clone https://github.com/AI-Hypercomputer/maxtext.git
 cd maxtext
-git checkout maxtext-tutorial-v1.4.0
-
-# Custom Jax and LibTPU wheels
-pip download libtpu==0.0.33.dev20251219+nightly -f"https://storage.googleapis.com/jax-releases/libtpu_releases.html"
-
-pip download --pre jax==0.8.3.dev20251219 jaxlib==0.8.3.dev20251219 --index https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/
+git checkout maxtext-tutorial-v1.5.0
 
 # Build and upload the docker image
-bash dependencies/scripts/docker_build_dependency_image.sh MODE=custom_wheels
+bash dependencies/scripts/docker_build_dependency_image.sh \
+  MODE=nightly \
+  JAX_VERSION=0.8.3.dev20251219 \
+  LIBTPU_VERSION=0.0.33.dev20251219+nightly
 bash dependencies/scripts/docker_upload_runner.sh CLOUD_IMAGE_NAME=${CLOUD_IMAGE_NAME}
 
 # Deactivate the virtual environment

--- a/training/ironwood/qwen3-235b-a22b/4k-bf16-tpu7x-4x8x8/xpk/README.md
+++ b/training/ironwood/qwen3-235b-a22b/4k-bf16-tpu7x-4x8x8/xpk/README.md
@@ -203,15 +203,13 @@ if [[ "$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_i
 # Clone MaxText Repository and Checkout Recipe Branch
 git clone https://github.com/AI-Hypercomputer/maxtext.git
 cd maxtext
-git checkout maxtext-tutorial-v1.4.0
-
-# Custom Jax and LibTPU wheels
-pip download libtpu==0.0.32.dev20251215+nightly -f"https://storage.googleapis.com/jax-releases/libtpu_releases.html"
-
-pip download --pre jax==0.8.2.dev20251215 jaxlib==0.8.2.dev20251215 --index https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/
+git checkout maxtext-tutorial-v1.5.0
 
 # Build and upload the docker image
-bash dependencies/scripts/docker_build_dependency_image.sh MODE=custom_wheels
+bash dependencies/scripts/docker_build_dependency_image.sh \
+  MODE=nightly \
+  JAX_VERSION=0.8.2.dev20251215 \
+  LIBTPU_VERSION=0.0.32.dev20251215+nightly
 bash dependencies/scripts/docker_upload_runner.sh CLOUD_IMAGE_NAME=${CLOUD_IMAGE_NAME}
 
 # Deactivate the virtual environment

--- a/training/ironwood/qwen3-235b-a22b/4k-fp8-tpu7x-4x8x8/README.md
+++ b/training/ironwood/qwen3-235b-a22b/4k-fp8-tpu7x-4x8x8/README.md
@@ -205,15 +205,13 @@ if [[ "$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_i
 # Clone MaxText Repository and Checkout Recipe Branch
 git clone https://github.com/AI-Hypercomputer/maxtext.git
 cd maxtext
-git checkout maxtext-tutorial-v1.4.0
-
-# Custom Jax and LibTPU wheels
-pip download libtpu==0.0.33.dev20251219+nightly -f"https://storage.googleapis.com/jax-releases/libtpu_releases.html"
-
-pip download --pre jax==0.8.3.dev20251219 jaxlib==0.8.3.dev20251219 --index https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/
+git checkout maxtext-tutorial-v1.5.0
 
 # Build and upload the docker image
-bash dependencies/scripts/docker_build_dependency_image.sh MODE=custom_wheels
+bash dependencies/scripts/docker_build_dependency_image.sh \
+  MODE=nightly \
+  JAX_VERSION=0.8.3.dev20251219 \
+  LIBTPU_VERSION=0.0.33.dev20251219+nightly
 bash dependencies/scripts/docker_upload_runner.sh CLOUD_IMAGE_NAME=${CLOUD_IMAGE_NAME}
 
 # Deactivate the virtual environment


### PR DESCRIPTION
MaxText PR (https://github.com/AI-Hypercomputer/maxtext/pull/2822) added the ability to pin lib versions within their docker image build script. This change adjusts to using this version of pinning to simplify the readme files and remove manual pip steps for these versions.