### PR TITLE
Remove deprecated flag: disable-log-requests

### DIFF
--- a/inference/trillium/vLLM/Llama3.x/README.md
+++ b/inference/trillium/vLLM/Llama3.x/README.md
@@ -125,7 +125,6 @@ export TP=8 # number of chips
 
 vllm serve meta-llama/Llama-3.3-70B-Instruct \
     --seed 42 \
-    --disable-log-requests \
     --no-enable-prefix-caching \
     --async-scheduling \
     --gpu-memory-utilization 0.98 \

--- a/inference/trillium/vLLM/Qwen2.5-32B/README.md
+++ b/inference/trillium/vLLM/Qwen2.5-32B/README.md
@@ -64,7 +64,7 @@ export TP=4 # number of chips
 # export RATIO=0.8
 # export PREFIX_LEN=0
 
-VLLM_USE_V1=1 vllm serve Qwen/Qwen2.5-32B --seed 42 --disable-log-requests --gpu-memory-utilization 0.98 --max-num-batched-tokens 2048 --max-num-seqs 128 --tensor-parallel-size $TP --max-model-len $MAX_MODEL_LEN
+VLLM_USE_V1=1 vllm serve Qwen/Qwen2.5-32B --seed 42  --gpu-memory-utilization 0.98 --max-num-batched-tokens 2048 --max-num-seqs 128 --tensor-parallel-size $TP --max-model-len $MAX_MODEL_LEN
 ```
 
 It takes a few minutes depending on the model size to prepare the server - once you see the below snippet in the logs, it means that the server is ready to serve requests or run benchmarks:


### PR DESCRIPTION
## Title
Update vLLM recipes to remove deprecated `--disable-log-requests` flag

## Description
This PR updates the `vllm serve` commands in the Llama 3.1 and Qwen 2.5 recipes to remove the `--disable-log-requests` flag. 

This flag was scheduled for removal in vLLM v0.12.0, as tracked in vllm-project/vllm#29402. Removing it now ensures our recipes remain compatible with upcoming vLLM releases and don't fail due to unrecognized arguments.

## Changes
- `inference/trillium/vLLM/Llama3.x/README.md`: Removed `--disable-log-requests` from the example command.
- `inference/trillium/vLLM/Qwen2.5-32B/README.md`: Removed `--disable-log-requests` from the example command.

## References
- vLLM PR for flag removal: https://github.com/vllm-project/vllm/pull/29402