### PR TITLE
update docker build path for Llama3.1-70B-MaxText Trillium recipes

### DIFF
--- a/training/trillium/Llama3.1-70B-MaxText/v6e-128/README.md
+++ b/training/trillium/Llama3.1-70B-MaxText/v6e-128/README.md
@@ -16,7 +16,7 @@ git checkout tpu-recipes-v0.1.4
 In step 3, use the jax-stable-stack image containing JAX 0.6.1:
 ```
 BASE_IMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-ai-image/tpu:jax0.6.1-rev1
-src/dependencies/scripts/docker_build_dependency_image.sh DEVICE=tpu MODE=stable BASEIMAGE=${BASE_IMAGE}
+bash src/dependencies/scripts/docker_build_dependency_image.sh DEVICE=tpu MODE=stable BASEIMAGE=${BASE_IMAGE}
 ```
 
 ## Run Maxtext Llama3.1-70B workloads on GKE

--- a/training/trillium/Llama3.1-70B-MaxText/v6e-128/README.md
+++ b/training/trillium/Llama3.1-70B-MaxText/v6e-128/README.md
@@ -16,7 +16,7 @@ git checkout tpu-recipes-v0.1.4
 In step 3, use the jax-stable-stack image containing JAX 0.6.1:
 ```
 BASE_IMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-ai-image/tpu:jax0.6.1-rev1
-bash docker_build_dependency_image.sh DEVICE=tpu MODE=stable_stack BASEIMAGE=${BASE_IMAGE}
+src/dependencies/scripts/docker_build_dependency_image.sh DEVICE=tpu MODE=stable BASEIMAGE=${BASE_IMAGE}
 ```
 
 ## Run Maxtext Llama3.1-70B workloads on GKE

--- a/training/trillium/Llama3.1-70B-MaxText/v6e-256/README.md
+++ b/training/trillium/Llama3.1-70B-MaxText/v6e-256/README.md
@@ -16,7 +16,7 @@ git checkout tpu-recipes-v0.1.4
 In step 3, use the jax-stable-stack image containing JAX 0.6.1:
 ```
 BASE_IMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-ai-image/tpu:jax0.6.1-rev1
-src/dependencies/scripts/docker_build_dependency_image.sh DEVICE=tpu MODE=stable BASEIMAGE=${BASE_IMAGE}
+bash src/dependencies/scripts/docker_build_dependency_image.sh DEVICE=tpu MODE=stable BASEIMAGE=${BASE_IMAGE}
 ```
 
 ## Run Maxtext Llama3.1-70B workloads on GKE

--- a/training/trillium/Llama3.1-70B-MaxText/v6e-256/README.md
+++ b/training/trillium/Llama3.1-70B-MaxText/v6e-256/README.md
@@ -16,7 +16,7 @@ git checkout tpu-recipes-v0.1.4
 In step 3, use the jax-stable-stack image containing JAX 0.6.1:
 ```
 BASE_IMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-ai-image/tpu:jax0.6.1-rev1
-bash docker_build_dependency_image.sh DEVICE=tpu MODE=stable_stack BASEIMAGE=${BASE_IMAGE}
+src/dependencies/scripts/docker_build_dependency_image.sh DEVICE=tpu MODE=stable BASEIMAGE=${BASE_IMAGE}
 ```
 
 ## Run Maxtext Llama3.1-70B workloads on GKE

--- a/training/trillium/Llama3.1-70B-MaxText/v6e-32/README.md
+++ b/training/trillium/Llama3.1-70B-MaxText/v6e-32/README.md
@@ -16,7 +16,7 @@ git checkout tpu-recipes-v0.1.4
 In step 3, use the jax-stable-stack image containing JAX 0.6.1:
 ```
 BASE_IMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-ai-image/tpu:jax0.6.1-rev1
-src/dependencies/scripts/docker_build_dependency_image.sh DEVICE=tpu MODE=stable BASEIMAGE=${BASE_IMAGE}
+bash src/dependencies/scripts/docker_build_dependency_image.sh DEVICE=tpu MODE=stable BASEIMAGE=${BASE_IMAGE}
 ```
 
 ## Run Maxtext Llama3.1-70B workloads on GKE

--- a/training/trillium/Llama3.1-70B-MaxText/v6e-32/README.md
+++ b/training/trillium/Llama3.1-70B-MaxText/v6e-32/README.md
@@ -16,7 +16,7 @@ git checkout tpu-recipes-v0.1.4
 In step 3, use the jax-stable-stack image containing JAX 0.6.1:
 ```
 BASE_IMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-ai-image/tpu:jax0.6.1-rev1
-bash docker_build_dependency_image.sh DEVICE=tpu MODE=stable_stack BASEIMAGE=${BASE_IMAGE}
+src/dependencies/scripts/docker_build_dependency_image.sh DEVICE=tpu MODE=stable BASEIMAGE=${BASE_IMAGE}
 ```
 
 ## Run Maxtext Llama3.1-70B workloads on GKE

--- a/training/trillium/Llama3.1-70B-MaxText/v6e-64/README.md
+++ b/training/trillium/Llama3.1-70B-MaxText/v6e-64/README.md
@@ -16,7 +16,7 @@ git checkout tpu-recipes-v0.1.4
 In step 3, use the jax-stable-stack image containing JAX 0.6.1:
 ```
 BASE_IMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-ai-image/tpu:jax0.6.1-rev1
-src/dependencies/scripts/docker_build_dependency_image.sh DEVICE=tpu MODE=stable BASEIMAGE=${BASE_IMAGE}
+bash src/dependencies/scripts/docker_build_dependency_image.sh DEVICE=tpu MODE=stable BASEIMAGE=${BASE_IMAGE}
 ```
 
 ## Run Maxtext Llama3.1-70B workloads on GKE

--- a/training/trillium/Llama3.1-70B-MaxText/v6e-64/README.md
+++ b/training/trillium/Llama3.1-70B-MaxText/v6e-64/README.md
@@ -16,7 +16,7 @@ git checkout tpu-recipes-v0.1.4
 In step 3, use the jax-stable-stack image containing JAX 0.6.1:
 ```
 BASE_IMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-ai-image/tpu:jax0.6.1-rev1
-bash docker_build_dependency_image.sh DEVICE=tpu MODE=stable_stack BASEIMAGE=${BASE_IMAGE}
+src/dependencies/scripts/docker_build_dependency_image.sh DEVICE=tpu MODE=stable BASEIMAGE=${BASE_IMAGE}
 ```
 
 ## Run Maxtext Llama3.1-70B workloads on GKE


### PR DESCRIPTION
This PR updates the Docker dependency build script path across all four trillium-training-Llama3.1-70B-MaxText recipes and ensures the correct parameters for MODE are passed.

Changes:
- Updated the build command path to:
  src/dependencies/scripts/docker_build_dependency_image.sh
- Standardized arguments to:
  MODE=stable
