### PR TITLE
Update inference/ironwood/vLLM/Qwen3-Coder-480B-A35B/README.md

### DIFF
--- a/inference/ironwood/vLLM/Qwen3-Coder-480B-A35B/README.md
+++ b/inference/ironwood/vLLM/Qwen3-Coder-480B-A35B/README.md
@@ -68,7 +68,7 @@ following steps to enable the required features.
     ```bash
     gcloud container clusters update ${CLUSTER_NAME} \
       --location=${REGION} \
-      --workload-pool=PROJECT_ID.svc.id.goog
+      --workload-pool=$PROJECT_ID.svc.id.goog
     ```
 
     To enable in existing nodepool.


### PR DESCRIPTION
This PR fixes the command to Enable Workload Identity for cluster in `inference/ironwood/vLLM/Qwen3-Coder-480B-A35B/README.md`. There is a missing `$` before `PROJECT_ID` in `workload-pool` flag.