### PR TITLE
Update tokens/chip for Qwen3-32B

### DIFF
--- a/inference/ironwood/vLLM/Qwen3-32B/README.md
+++ b/inference/ironwood/vLLM/Qwen3-32B/README.md
@@ -645,9 +645,9 @@ First, download the client code: `git clone https://github.com/SemiAnalysisAI/In
 
     Workload | Output Token Throughput (tok/s) Per Chip
     :------- | :---------------------------------------
-    1k/1k    | 6467.74
-    1k/8k    | 3958.72
-    8k/1k    | 1357.34
+    1k/1k    | 6556.72
+    1k/8k    | 3959.56
+    8k/1k    | 1382.18
 
     **Note**: These benchmark results are based on the `InferenceX` client. The
     development team is continuously improving and optimizing performance; as such,


### PR DESCRIPTION
Run Id: 

1k/1k: vllm_inference-qwen3_32b_1k_1k-2026-04-02_120929-2b95cdf8-75d4-4402-bd4c-dd444f090e5c

1k/8k: vllm_inference-qwen3_32b_1k_8k-2026-03-30_093354-1fdb443f-f9c6-43cf-bde4-2cfa2ac4fc95

8k/1k: vllm_inference-qwen3_32b_8k_1k-2026-04-01_173745-046bfbc4-0194-4457-acc0-e0f0b1067eae