### PR TITLE
Update Ironwood recipe for Gemma4

### DIFF
--- a/inference/ironwood/vLLM/Gemma4/gemma4-server.yaml
+++ b/inference/ironwood/vLLM/Gemma4/gemma4-server.yaml
@@ -65,6 +65,7 @@ spec:
         - --no-enable-prefix-caching
         - --additional_config='{"quantization": { "qwix": { "rules": [{ "module_path": ".*", "weight_qtype": "float8_e4m3fn", "act_qtype": "float8_e4m3fn"}]}}}'
         # TODO: Update the model if you wish to switch to MoE or another variant
+        # For google/gemma-4-26B-A4B-it, it's recommended to remove above qwix quantization flags, and use TP size 4
         - --model=google/gemma-4-31B-it
         - --async-scheduling
         - --gpu-memory-utilization=0.90

--- a/inference/ironwood/vLLM/Gemma4/gemma4-server.yaml
+++ b/inference/ironwood/vLLM/Gemma4/gemma4-server.yaml
@@ -59,10 +59,11 @@ spec:
         # TODO: Update tensor-parallel-size to match the number of chips in your topology
         - --tensor-parallel-size=2
         - --max-model-len=16384
-        - --max-num-batched-tokens=16384
+        - --max-num-batched-tokens=4096
         - --block-size=256
         - --download-dir=/data
         - --no-enable-prefix-caching
+        - --additional_config='{"quantization": { "qwix": { "rules": [{ "module_path": ".*", "weight_qtype": "float8_e4m3fn", "act_qtype": "float8_e4m3fn"}]}}}'
         # TODO: Update the model if you wish to switch to MoE or another variant
         - --model=google/gemma-4-31B-it
         - --async-scheduling

--- a/inference/ironwood/vLLM/Gemma4/gemma4-server.yaml
+++ b/inference/ironwood/vLLM/Gemma4/gemma4-server.yaml
@@ -46,10 +46,10 @@ spec:
       # TODO: Update the topology to match your allocated TPU node pool (e.g., 2x2x1 is 4 chips)
       nodeSelector:
         cloud.google.com/gke-tpu-accelerator: tpu7x
-        cloud.google.com/gke-tpu-topology: 2x2x1
+        cloud.google.com/gke-tpu-topology: 1x1x1
       containers:
       - name: vllm-tpu
-        image: vllm/vllm-tpu:gemma4
+        image: vllm/vllm-tpu:nightly
         command: ["python3", "-m", "vllm.entrypoints.openai.api_server"]
 
         args:
@@ -57,8 +57,10 @@ spec:
         - --port=8000
         - --seed=42
         # TODO: Update tensor-parallel-size to match the number of chips in your topology
-        - --tensor-parallel-size=8
+        - --tensor-parallel-size=2
         - --max-model-len=16384
+        - --max-num-batched-tokens=16384
+        - --block-size=256
         - --download-dir=/data
         - --no-enable-prefix-caching
         # TODO: Update the model if you wish to switch to MoE or another variant
@@ -70,6 +72,8 @@ spec:
         - --tool-call-parser=gemma4
 
         env:
+        - name: USE_BATCHED_RPA_KERNEL
+          value: 1
         - name: HF_HOME
           value: /data
         - name: HF_TOKEN
@@ -82,9 +86,9 @@ spec:
         - containerPort: 8000
         resources:
           limits:
-            google.com/tpu: '4' # Number of chips required by topology
+            google.com/tpu: '1' # Number of chips required by topology
           requests:
-            google.com/tpu: '4'
+            google.com/tpu: '1'
         readinessProbe:
           tcpSocket:
             port: 8000


### PR DESCRIPTION
Perf. on ironwood (v7x)
```
vllm bench serve \
    --model google/gemma-4-31B-it \
    --dataset-name random \
    --random-input-len 1024 \
    --random-output-len 1024 \
    --num-prompts 320 \
    --ignore-eos \
    --temperature=0

============ Serving Benchmark Result ============
Successful requests:                     320
Failed requests:                         0
Benchmark duration (s):                  189.72
Total input tokens:                      327680
Total generated tokens:                  327680
Request throughput (req/s):              1.69
Output token throughput (tok/s):         1727.14
Peak output token throughput (tok/s):    3432.00
Peak concurrent requests:                320.00
Total token throughput (tok/s):          3454.28
---------------Time to First Token----------------
Mean TTFT (ms):                          50174.86
Median TTFT (ms):                        53658.99
P99 TTFT (ms):                           106359.44
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          53.80
Median TPOT (ms):                        47.61
P99 TPOT (ms):                           83.25
---------------Inter-token Latency----------------
Mean ITL (ms):                           53.80
Median ITL (ms):                         42.96
P99 ITL (ms):                            183.69
==================================================