### PR TITLE
feat(llama3.1-8b): migrate MaxText training workload to gcluster

### DIFF
--- a/training/trillium/Llama3.1-8B-MaxText/v6e-8/README.md
+++ b/training/trillium/Llama3.1-8B-MaxText/v6e-8/README.md
@@ -1,39 +1,50 @@
 # Instructions for training Llama3.1-8B-MaxText on TPU trillium (v6e-8)
 
-## XPK setup
-Please follow the [XPK_README](https://github.com/AI-Hypercomputer/tpu-recipes/blob/main/training/XPK_README.md) to create your GKE cluster with XPK
+## GCluster setup
+Please set up the cluster and download the `gcluster` tool. You should configure your environment variables as described below.
+
+> [!TIP]
+> For a detailed, comprehensive guide on the GCluster workload submission framework, dynamic configuration overrides, and advanced scheduling capabilities, refer to the official [GCluster Job Guide](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/docs/gcluster_job_guide.md).
+
 
 ## Prep for Maxtext
 
 ### Install MaxText and Build Docker Image
-Please follow the [MAXTEXT_README](https://github.com/AI-Hypercomputer/tpu-recipes/blob/main/training/MAXTEXT_README.md) to install maxtext and build the docker image. The following variables should be set:
+Please install MaxText and build a Docker image pushed to Google Artifact Registry or container registry. 
 
-In step 1, use the MaxText [tpu-recipes-v0.1.4](https://github.com/AI-Hypercomputer/maxtext/releases/tag/tpu-recipes-v0.1.4) tag to run this recipe:
-```
-git checkout tpu-recipes-v0.1.4
+Ensure the following variables are set in your environment:
+```bash
+export CLUSTER_NAME="" # The name of your GKE cluster
+export PROJECT=""       # Your GCP project ID
+export LOCATION=""      # The location/zone/region of your GKE cluster
+export IMAGE_NAME=""    # Your pre-built container image URL
+export OUTPUT_DIR=""    # GCS bucket path (e.g. gs://my-bucket/maxtext_output)
+
+# Optional overrides:
+export COMPUTE_TYPE=""  # GKE TPU node type (defaults to "v6e-4")
+export TOPOLOGY=""      # Slice topology (defaults to "2x4")
+export QUEUE=""         # Kueue LocalQueue (defaults to "multislice-queue")
 ```
 
-In step 3, use the jax-stable-stack image containing JAX 0.6.1:
-```
-BASE_IMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-ai-image/tpu:jax0.6.1-rev1
-bash docker_build_dependency_image.sh DEVICE=tpu MODE=stable_stack BASEIMAGE=${BASE_IMAGE}
-```
 
 ## Run Maxtext Llama3.1-8B workloads on GKE
 
-### Starting workload
+### 1. Optional: Setting up Kueue Queues (First-Time Setup Only)
 
-From the MaxText root directory, start your Llama3.1-8B workload.
+If you are running on a freshly deployed GKE cluster, or if Kueue is installed but its resource queues have not been configured, the submitted jobs will hang in a `Pending` (Not Admitted) state. 
+
+You can configure the required topology-aware Kueue queues by executing:
+```bash
+kubectl apply -f kueue-resources.yaml
 ```
-python3 -m benchmarks.benchmark_runner xpk \
-    --project=$PROJECT \
-    --zone=$ZONE \
-    --device_type=v6e-8 \
-    --num_slices=1  \
-    --cluster_name=${CLUSTER_NAME} \
-    --base_output_directory=${OUTPUT_DIR} \
-    --model_name="llama3_1_8b_8192_no_collective_matmul" \
-    --base_docker_image=maxtext_base_image
+*This provisions a `ResourceFlavor`, `ClusterQueue`, and `LocalQueue` in your namespace configured specifically to admit and schedule this TPU topology workload.*
+
+### 2. Starting Workload
+
+From the recipe directory, run the `gcluster` workload submission script:
+
+```bash
+bash llama3-1-8B-1xv6e-8-gcluster.sh
 ```
 
 From your workload logs, you should start seeing step time logs like the following:
@@ -90,3 +101,63 @@ MaxTextModel(
 ```
 
 This equivalent workload code can be found in the [maxtext_trillium_model_configs.py](https://github.com/AI-Hypercomputer/maxtext/blob/9f1820b472ef362e7b5c782fe1d6fda8a0943eff/benchmarks/maxtext_trillium_model_configs.py) file within the MaxText repository.
+
+## Troubleshooting & Operations
+
+This section lists common errors and commands to manage and troubleshoot your GCluster workloads.
+
+### 1. Useful Operations Commands
+
+* **List submitted workloads:**
+  ```bash
+  gcluster job list --cluster "$CLUSTER_NAME" --location "$LOCATION" --project "$PROJECT"
+  ```
+* **View workload logs:**
+  ```bash
+  gcluster job logs [workload-name] --cluster "$CLUSTER_NAME" --location "$LOCATION" --project "$PROJECT"
+  ```
+  *(Or use `kubectl logs -f [pod-name]` for native Kubernetes logging)*
+* **Cancel/delete a workload:**
+  ```bash
+  gcluster job cancel [workload-name] --cluster "$CLUSTER_NAME" --location "$LOCATION" --project "$PROJECT"
+  ```
+
+---
+
+### 2. Common Errors & Solutions
+
+#### A. PriorityClass Update Failure (`Forbidden: may not be changed in an update`)
+If you upgrade Kueue or re-install it, you may see the following error:
+```
+Error: kubectl apply failed with exit code 1: PriorityClass.scheduling.k8s.io "very-low" is invalid: value: Forbidden: may not be changed in an update.
+```
+* **Cause:** GKE `PriorityClass` values are immutable once created, and updating them triggers an API server rejection.
+* **Solution:** Manually delete the conflicting classes and re-run submission:
+  ```bash
+  kubectl delete priorityclass very-low low medium high very-high
+  ```
+
+#### B. Compile-Time Out-of-Memory (`CompileTimeHbmOom` / `RESOURCE_EXHAUSTED`)
+When running on smaller TPU node slices (like `v6e-4` with a `2x2` topology) with the default Llama 3.1 8B settings, you may see:
+```
+jax.errors.JaxRuntimeError: RESOURCE_EXHAUSTED: E1000: CompileTimeHbmOom: XLA:TPU compile permanent error. Ran out of memory in memory space hbm.
+```
+* **Cause:** Storing parameters and large context attention activations exceeds the physical 32 GB HBM memory on individual v6e chips.
+* **Solution:** Reduce the memory footprint in the training command arguments within `llama3-1-8B-1xv6e-8-gcluster.sh`:
+  1. Change `per_device_batch_size` from `3` to **`1`** (Line 56).
+  2. Reduce `max_target_length` from `8192` to **`2048`** or **`4096`** (Line 63).
+
+#### C. Artifact Registry Pull Access Denied (`ErrImagePull` / `403 Forbidden`)
+If your pods are admitted but remain in `Pending` with an `ErrImagePull` status:
+```
+failed to authorize: failed to fetch oauth token: unexpected status from GET request: 403 Forbidden
+```
+* **Cause:** GKE's node pool Service Account does not have IAM permission to read from your custom Google Artifact Registry repository.
+* **Solution:** Find your node pool service account name (typically `[node-pool-prefix]-gke-np-sa@...` or Compute Engine default) and grant the reader role:
+  ```bash
+  gcloud artifacts repositories add-iam-policy-binding [repo-name] \
+      --location=[repo-region] \
+      --member="serviceAccount:[your-gke-node-sa]@[project-id].iam.gserviceaccount.com" \
+      --role="roles/artifactregistry.reader" \
+      --project=[project-id]
+  ```

--- a/training/trillium/Llama3.1-8B-MaxText/v6e-8/kueue-resources.yaml
+++ b/training/trillium/Llama3.1-8B-MaxText/v6e-8/kueue-resources.yaml
@@ -1,0 +1,32 @@
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  name: 1xv6e-8
+spec:
+  nodeLabels:
+    cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
+    cloud.google.com/gke-tpu-topology: 2x4
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: cluster-queue
+spec:
+  namespaceSelector: {}
+  queueingStrategy: BestEffortFIFO
+  resourceGroups:
+  - coveredResources:
+    - google.com/tpu
+    flavors:
+    - name: 1xv6e-8
+      resources:
+      - name: google.com/tpu
+        nominalQuota: 8
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: LocalQueue
+metadata:
+  name: multislice-queue
+  namespace: default
+spec:
+  clusterQueue: cluster-queue

--- a/training/trillium/Llama3.1-8B-MaxText/v6e-8/llama3-1-8B-1xv6e-8-gcluster.sh
+++ b/training/trillium/Llama3.1-8B-MaxText/v6e-8/llama3-1-8B-1xv6e-8-gcluster.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+# Exit on error
+set -e
+
+# Read the configuration from environment variables or use defaults.
+CLUSTER_NAME=${CLUSTER_NAME:-"v6e-8-brahmai-cluster"}
+PROJECT=${PROJECT:-"gke-aishared-gsc-dev"}
+LOCATION=${LOCATION:-"southamerica-west1"}
+IMAGE_NAME=${IMAGE_NAME:-"southamerica-west1-docker.pkg.dev/gke-aishared-gsc-dev/jetstream-maxtext-ar-kimi-k2/bhramai-base-image:latest"}
+OUTPUT_DIR=${OUTPUT_DIR:-"gs://gke-aishared-gsc-dev/maxtext_output"}
+RUN_NAME=${RUN_NAME:-"llama3-1-8b-run-$(date +%Y%m%d-%H%M)"}
+QUEUE=${QUEUE:-"multislice-queue"}
+COMPUTE_TYPE=${COMPUTE_TYPE:-"v6e-4"}
+TOPOLOGY=${TOPOLOGY:-"2x4"}
+JOB_NAME=${JOB_NAME:-"llama3-1-8b-${TOPOLOGY}-$(date +%H%M)"}
+
+
+# Read the inline training workload command to execute inside the container
+read -r -d '' COMMAND_CONTENT << 'EOF' || true
+#!/bin/bash
+set -e
+echo "Starting MaxText Workload..."
+
+# 1. Set environment variables
+export LIBTPU_INIT_ARGS=" --xla_tpu_scoped_vmem_limit_kib=98304 --xla_tpu_assign_all_reduce_scatter_layout=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_sparse_core_collective_offload_all_gather=true --xla_tpu_enable_sparse_core_collective_offload_reduce_scatter=true --xla_tpu_enable_sparse_core_collective_offload_all_reduce=true --xla_tpu_aggressive_opt_barrier_removal=ENABLED"
+export JAX_PLATFORMS=""
+export ENABLE_PJRT_COMPATIBILITY="true"
+
+# 2. Detect MaxText module to run pre-training
+TRAIN_CMD=""
+if python3 -c "import importlib.util; exit(0 if importlib.util.find_spec('maxtext.trainers.pre_train.train') is not None else 1)" &>/dev/null; then
+    TRAIN_CMD="python3 -m maxtext.trainers.pre_train.train maxtext/configs/base.yml"
+elif python3 -c "import importlib.util; exit(0 if importlib.util.find_spec('maxtext.train') is not None else 1)" &>/dev/null; then
+    TRAIN_CMD="python3 -m maxtext.train maxtext/configs/base.yml"
+elif python3 -c "import importlib.util; exit(0 if importlib.util.find_spec('MaxText.train') is not None else 1)" &>/dev/null; then
+    if [ -d "/deps/src/maxtext/configs" ]; then
+        TRAIN_CMD="python3 -m MaxText.train /deps/src/maxtext/configs/base.yml"
+    else
+        TRAIN_CMD="python3 -m MaxText.train MaxText/configs/base.yml"
+    fi
+else
+    echo "Error: Could not find MaxText training module. Please verify MaxText installation inside the container."
+    exit 1
+fi
+
+# 3. Execute training
+$TRAIN_CMD \
+    model_name="llama3.1-8b" \
+    run_name="${RUN_NAME}" \
+    steps=30 \
+    base_output_directory="${OUTPUT_DIR}" \
+    per_device_batch_size=3 \
+    ici_fsdp_parallelism=-1 \
+    remat_policy="custom" \
+    decoder_layer_input="offload" \
+    out_proj="offload" \
+    query_proj="offload" \
+    key_proj="offload" \
+    value_proj="offload" \
+    max_target_length=8192 \
+    attention="flash" \
+    use_iota_embed=True \
+    dataset_path="gs://max-datasets-rogue" \
+    dataset_type="synthetic" \
+    enable_checkpointing=False \
+    sa_block_q=2048 \
+    sa_block_kv=2048 \
+    sa_block_kv_compute=2048 \
+    sa_block_q_dkv=2048 \
+    sa_block_kv_dkv=2048 \
+    sa_block_kv_dkv_compute=2048 \
+    sa_block_q_dq=2048 \
+    sa_block_kv_dq=2048 \
+    sa_use_fused_bwd_kernel=True \
+    profiler="xplane" \
+    skip_first_n_steps_for_profiler=10 \
+    profiler_steps=5 \
+    use_vertex_tensorboard=false
+EOF
+
+echo "Submitting MaxText Llama3.1-8B job to cluster $CLUSTER_NAME..."
+echo "  PROJECT:     $PROJECT"
+echo "  LOCATION:    $LOCATION"
+echo "  IMAGE:       $IMAGE_NAME"
+echo "  OUTPUT_DIR:  $OUTPUT_DIR"
+echo "  RUN_NAME:    $RUN_NAME"
+echo "  QUEUE:       $QUEUE"
+
+# Find the gcluster binary dynamically by checking local and home paths first
+GCLUSTER="gcluster"
+for candidate in \
+  "$(dirname "${BASH_SOURCE[0]}")/gcluster" \
+  "$(dirname "${BASH_SOURCE[0]}")/../../../../../cluster-toolkit/gcluster" \
+  "./gcluster" \
+  "../gcluster" \
+  "${HOME}/cluster-toolkit/gcluster" \
+  "${HOME}/xpk-devwork/cluster-toolkit/gcluster"; do
+  if [ -f "$candidate" ]; then
+    GCLUSTER="$(cd "$(dirname "$candidate")" && pwd)/$(basename "$candidate")"
+    break
+  fi
+done
+
+# Submit job using gcluster job submit
+$GCLUSTER --cluster "$CLUSTER_NAME" --location "$LOCATION" --project "$PROJECT" job submit \
+    --name "$JOB_NAME" \
+    --image "$IMAGE_NAME" \
+    --command "export RUN_NAME='$RUN_NAME' OUTPUT_DIR='$OUTPUT_DIR' && $COMMAND_CONTENT" \
+    --compute-type "$COMPUTE_TYPE" \
+    --topology "$TOPOLOGY" \
+    --priority medium \
+    --queue "$QUEUE"


### PR DESCRIPTION
- Refactors the workload execution template to support Cluster Toolkit's `gcluster` framework.
- Parameterizes GKE cluster and slice properties dynamically via environment variables.
- Adds declarative `kueue-resources.yaml` defining topology resource flavors for v6e queue scheduling.
- Updates `README.md` with comprehensive migration setup guides, useful CLI operations commands, and detailed compile-time OOM/IAM authorization troubleshooting mitigations.

Logs: https://paste.googleplex.com/5888432009248768#l=1