### PR TITLE
Add Ironwod microbenchmark recipes

### DIFF
--- a/microbenchmarks/ironwood/README.md
+++ b/microbenchmarks/ironwood/README.md
@@ -1,0 +1,270 @@
+# Microbenchmarks
+Microbenchmarks that assess the performance of individual operations and components on Ironwood accelerators with JAX.
+
+## Prerequisites
+
+- Ensure [gcloud CLI](https://docs.cloud.google.com/sdk/docs/install) is installed in your local machine.
+- Ensure `kubectl` is installed in your local machine: `gcloud components install kubectl
+`
+- Create a Cloud TPU GKE cluster, which uses GKE version >= `1.34.0-gke.2201000`
+- Ensure you have sufficient number of chips. This guide provisions two slices; one `2x2x1` (single host) slice and one `4x4x4` (multi host) slice and therefore requires 68 chips.
+
+Refer to ["Deploy TPU workloads in GKE" guide](https://cloud.google.com/kubernetes-engine/docs/how-to/tpus) for more information about how to set up a TPU GKE cluster with sufficient resources.
+
+## Setup
+
+Create one `2x2x1` nodepool in your GKE cluster:
+
+```bash
+# The default GKE version may be lower than `1.34.0-gke.2201000`. Check if `node-version` should be specified before applying this command.
+gcloud container node-pools create ${SINGLE_SLICE_NODE_POOL_NAME} \
+    --cluster=${CLUSTER_NAME} \
+    --machine-type=tpu7x-standard-4t \
+    --location=${LOCATION} \
+    --node-locations=${LOCATION} \
+    --project=${PROJECT_ID} \
+    --num-nodes=1 \
+    --reservation=${RESERVATION_NAME} \
+    --reservation-affinity=specific
+```
+
+Create one `4x4x4` nodepool in your GKE cluster using workload policy:
+
+```bash
+gcloud compute resource-policies create workload-policy ${WORKLOAD_POLICY_NAME} \
+    --type HIGH_THROUGHPUT \
+    --accelerator-topology 4x4x4 \
+    --project ${PROJECT_ID} \
+    --region ${REGION}
+
+# The default GKE version may be lower than `1.34.0-gke.2201000`. Check if `node-version` should be specified before applying this command.
+gcloud container node-pools create ${MULTI_SLICE_NODE_POOL_NAME} \
+    --cluster=${CLUSTER_NAME} \
+    --machine-type=tpu7x-standard-4t \
+    --placement-policy=${WORKLOAD_POLICY_NAME} \
+    --project ${PROJECT_ID} \
+    --location=${LOCATION} \
+    --reservation=${RESERVATION_NAME} \
+    --reservation-affinity=specific
+```
+
+Note: `$LOCATION` can either be the GCP zone or region depending on the GKE cluster configuration.
+
+Nodepool provisioning commands may vary depending on the GKE cluster setup. Please refer to ["Deploy TPU workloads in GKE" guide](https://cloud.google.com/kubernetes-engine/docs/how-to/tpus#create-node-pool) for all of the options.
+
+If the default Google Kubernetes Engine (GKE) version is less than `1.34.0-gke.2201000`, the minimum required version for Ironwood, the node-version argument must be specified during node pool creation. Furthermore, the cluster's GKE version must also be equal to or greater than `1.34.0-gke.2201000`, settable via the cluster-version argument.
+
+
+## Running the microbenchmarks in the GKE cluster
+
+Get credentials for the GKE cluster:
+
+```bash
+gcloud container clusters get-credentials ${CLUSTER_NAME} --location ${LOCATION} --project ${PROJECT_ID}
+```
+
+Verify that you have sufficient `gke-tpu-.*` nodes:
+
+```bash
+kubectl get nodes
+```
+
+### Deploying a single host job
+
+Create a job manifest to run `2x2x1` microbenchmarks (`tpu7x-2x2x1-micobenchmarks.yaml`):
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tpu7x-single-host-microbenchmark
+spec:
+  restartPolicy: Never
+  nodeSelector:
+    cloud.google.com/gke-tpu-accelerator: tpu7x
+    cloud.google.com/gke-tpu-topology: 2x2x1
+  containers:
+  - name: tpu-job
+    image: python:3.12
+    ports:
+    - containerPort: 8431
+    securityContext:
+      privileged: false
+    command:
+    - bash
+    - -c
+    - |
+      set -ex
+
+      git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+      cd accelerator-microbenchmarks
+      pip install -r requirements.txt
+
+      sh ./Ironwood/scripts/run_training_compute_microbenchmark.sh
+
+    resources:
+      requests:
+        google.com/tpu: 4
+      limits:
+        google.com/tpu: 4
+```
+
+Deploy the 2x2x1 microbenchmarks:
+
+```bash
+kubectl apply -f tpu7x-2x2x1-micobenchmarks.yaml
+```
+
+Monitor the results:
+
+```bash
+kubectl logs tpu7x-single-host-microbenchmark
+```
+
+Cleanup the job:
+
+```bash
+kubectl delete pod tpu7x-single-host-microbenchmark
+```
+
+### Deploying a multi host job
+
+Create a job manifest to run `4x4x4` microbenchmarks (`tpu7x-4x4x4-micobenchmarks.yaml`):
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-svc
+spec:
+  clusterIP: None
+  selector:
+    job-name: tpu7x-multi-host-microbenchmark
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: tpu7x-multi-host-microbenchmark
+spec:
+  completionMode: Indexed
+  parallelism: 16
+  completions: 16
+  backoffLimit: 0
+  template:
+    spec:
+      subdomain: headless-svc
+      restartPolicy: Never
+      nodeSelector:
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 4x4x4
+      containers:
+      - name: jax-tpu
+        image: python:3.12
+        securityContext:
+          privileged: false
+        env:
+        - name: JAX_PLATFORMS
+          value: "tpu,cpu"
+        - name: TPU_VMODULE
+          value: "singleton_tpu_system_manager=10,tpu_version_flag=10,device_util=10,device_scanner=10,mesh_builder=10,master=10"
+        - name: XLA_IR_DEBUG
+          value: "1"
+        - name: XLA_HLO_DEBUG
+          value: "1"
+        command:
+        - bash
+        - -c
+        - |
+          set -ex
+
+          git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+          cd accelerator-microbenchmarks
+          pip install -r requirements.txt
+
+          sh ./Ironwood/scripts/run_ici_microbenchmark_full.sh
+
+        resources:
+          requests:
+            google.com/tpu: 4
+          limits:
+            google.com/tpu: 4
+```
+
+Deploy the 4x4x4 microbenchmarks:
+
+```bash
+kubectl apply -f tpu7x-4x4x4-micobenchmarks.yaml
+```
+
+List all the jobs in the pod to get the name of a job:
+```bash
+kubectl get pods
+```
+
+Monitor the results of the job name picked above (monitoring only a single job is sufficient as all jobs will have the same logs):
+
+```bash
+kubectl logs tpu7x-multi-host-microbenchmark-0-XXXXX
+```
+
+Cleanup the job:
+
+```bash
+kubectl delete -f tpu7x-4x4x4-micobenchmarks.yaml
+```
+
+## Microbenchmark scripts
+
+### Compute
+
+`Ironwood/scripts/run_training_compute_microbenchmark.sh` script runs the training compute microbenchmark, including gemm, add, quantization, and transpose quantization:
+
+| Operation | Function Description | Formula / Logic |
+| :--- | :--- | :--- |
+| **`gemm_multiple_run`** | **Configurable GEMM.** Benchmarks matmul with configurable input types (supports `float8_e4m3fn`, `bfloat16`). Accumulation is FP32, output cast to BF16. Rerun multiple times and record all profilers.<br>**Example YAML.** [Ironwood/configs/training/gemm_multiple_run_more.yaml](https://github.com/AI-Hypercomputer/accelerator-microbenchmarks/blob/main/Ironwood/configs/training/gemm_multiple_run_more.yaml) | $O_{bf16} = (A \times B)$ |
+| **`gemm_simple`** | **Basic FP8 GEMM.** Benchmarks pure FP8 matmul with FP32 accumulation.<br>**Example YAML.** [Ironwood/configs/training/gemm_simple.yaml](https://github.com/AI-Hypercomputer/accelerator-microbenchmarks/blob/main/Ironwood/configs/training/gemm_simple.yaml) | $O_{bf16} = (A_{fp8} \times B_{fp8})$ |
+| **`gemm`** | **FP8 GEMM + Scaling.** Performs FP8 matmul and applies scaling factors (dequantization) to the result.<br>**Example YAML.** [Ironwood/configs/training/gemm.yaml](https://github.com/AI-Hypercomputer/accelerator-microbenchmarks/blob/main/Ironwood/configs/training/gemm.yaml) | $O_{bf16} = (A_{fp8} \times B_{fp8}) \times (S_A \times S_B^T)$ |
+| **`gemm_accum`** | **FP8 GEMM + Accumulation.** Performs FP8 matmul with scaling factors and accumulates the result into an existing FP32 output buffer.<br>**Example YAML.** [Ironwood/configs/training/gemm_accum.yaml](https://github.com/AI-Hypercomputer/accelerator-microbenchmarks/blob/main/Ironwood/configs/training/gemm_accum.yaml) | $O_{fp32} \ += (A_{fp8} \times B_{fp8}) \times (S_A \times S_B^T)$ |
+| **`gemm_fp8_rowwise`** | **FP8 Row-wise GEMM.** Quantizes inputs dynamically (row-wise/channel-wise) using absmax calibration before performing the matrix multiplication.<br>**Example YAML.** [Ironwood/configs/training/gemm_fp8_rowwise.yaml](https://github.com/AI-Hypercomputer/accelerator-microbenchmarks/blob/main/Ironwood/configs/training/gemm_fp8_rowwise.yaml) | $O_{bf16} = (Quant(A) \times Quant(B))$ |
+| **`add`** | **Element-wise Addition.** Adds two BF16 tensors.<br>**Example YAML.** [Ironwood/configs/training/add.yaml](https://github.com/AI-Hypercomputer/accelerator-microbenchmarks/blob/main/Ironwood/configs/training/add.yaml) | $Z = X + Y$ |
+| **`quantization`** | **Dynamic Quantization.** Quantizes a BF16 input tensor to FP8 using dynamic scaling (absmax calibration). Returns quantized values and scale factors.<br>**Example YAML.** [Ironwood/configs/training/quantization.yaml](https://github.com/AI-Hypercomputer/accelerator-microbenchmarks/blob/main/Ironwood/configs/training/quantization.yaml) | $S = \frac{Max}{absmax(X)}$, $O = Cast(\frac{X}{S})$ |
+| **`transpose_quantization`** | **Transpose + Quantization.** Transposes a BF16 input tensor first, then applies dynamic quantization.<br>**Example YAML.** [Ironwood/configs/training/transpose_quantization.yaml](https://github.com/AI-Hypercomputer/accelerator-microbenchmarks/blob/main/Ironwood/configs/training/transpose_quantization.yaml) | $S = \frac{Max}{absmax(X^T)}$, $O = Cast(\frac{X^T}{S})$ |
+
+### Collectives
+
+`Ironwood/scripts/run_ici_microbenchmark_full.sh` script runs the collective microbenchmarks, including psum, psum_scatter, all_gather, and all_to_all:
+
+| Operation | Function Description | Formula / Logic |
+| :--- | :--- | :--- |
+| **`psum`** | **All-Reduce (Sum).** Sums tensors across devices. | $O = \sum X_i$ |
+| **`psum_scatter`** | **Reduce-Scatter (Sum).** Sums tensors and scatters results. | $O_i = \sum X_i$ (scattered) |
+| **`all_gather`** | **All-Gather.** Gathers tensors from all devices. | $O = [X_0, X_1, ...]$ |
+| **`all_to_all`** | **All-to-All.** Scatters and gathers data between all devices. | Scatters/Gathers across devices |
+
+
+## Results
+
+### GEMM
+The table below summarizes the throughput performance (in `TFLOP/s` per device) for gemm_multiple_run across varying bfloat16 matrix sizes. (Used config: gemm_multiple_run_more.yaml.)
+
+| Matrix Size (m=n=k) | Throughput (`TFLOP/s/device`) |
+| :--- | :--- |
+| 128 | 2.589961271 |
+| 256 | 18.28645367 |
+| 512 | 105.0783466 |
+| 1024 | 349.7270639 |
+| 2048 | 679.284728 |
+| 4096 | 892.9445127 |
+| 16384 | 950.1286983 |
+| 32768 | 956.3824592 |
+
+
+## Examine the outputs
+
+The benchmarks will print metrics to the terminal. If you wish to dump formatted metrics in a file, you may set this parameter in your YAML file:
+* `csv_path`: Dumps the benchmark metrics in a CSV.
+Examples can be found in the YAML files under config/ directory.
+
+If you wish to generate the xprof profile, set this parameter in the YAML file:
+* `trace_dir`: Dumps the xprof profile to either a local location or GCS bucket.
+Examples can be found in the YAML files under config/ directory.

--- a/microbenchmarks/ironwood/automation/README.md
+++ b/microbenchmarks/ironwood/automation/README.md
@@ -1,0 +1,107 @@
+# Ironwood Benchmark Automation
+
+This directory contains the automation framework for running TPU microbenchmarks (HBM, Host-Device, Collectives, etc.) on GKE clusters. The tool simplifies the workflow of launching multiple benchmark jobs via [Kueue](https://kueue.sigs.k8s.io/), monitoring their status, handling retries, and aggregating the final results into a unified format.
+
+## Overview
+
+The automation workflow consists of three main stages:
+1.  **Launch**: Submits Kubernetes Jobs for various benchmark configurations (e.g., different topologies like 2x2x1, 2x2x2) using Kueue for queue management.
+2.  **Monitor & Retry**: Watches the jobs until completion. If any job fails, it automatically retries them (up to 3 times by default).
+3.  **Aggregate**: Once all jobs succeed, an aggregator job is launched to collect all intermediate results from GCS and consolidate them into summary TSV files.
+
+## Prerequisites
+
+Before running the automation script, ensure the following requirements are met:
+
+### 1. Environment Setup
+*   **GKE Cluster**: You must have a GKE cluster with TPU node pools configured.
+*   **Kubectl**: Ensure `kubectl` is installed and authenticated to your cluster.
+*   **GCS Bucket**: A Google Cloud Storage bucket is required to store intermediate and final aggregated results.
+    ```bash
+    gcloud storage buckets create gs://my-unique-bucket-name --location=us-central1
+    ```
+
+### 2. Install Kueue
+The automation relies on Kueue for job queuing. Check if it's already installed:
+
+```bash
+kubectl get namespace kueue-system
+```
+
+If you see `Error from server (NotFound)`, install it with:
+
+```bash
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.16.0/manifests.yaml
+```
+
+### 3. Verify Node Pool Topology
+The script expects specific TPU node pools (e.g., `tpu7x-2x2x1`, `tpu7x-2x2x2`) to be available. The `check_node_pool_setup.sh` utility will automatically validate this before launching jobs.
+
+## Directory Structure
+
+*   `automation_launch.sh`: The main entry point script. Manages the full lifecycle of the benchmark run.
+*   `check_node_pool_setup.sh`: Validation script to ensure required node pools exist in the cluster.
+*   `aggregator.py`: Python script that downloads results from GCS and produces summary tables.
+*   `aggregator.yaml`: Kubernetes Job definition for running the aggregator.
+*   `job-queue.yaml`: Kueue resource definitions (ClusterQueue, LocalQueue).
+*   `*.yaml`: Benchmark job configurations (e.g., `tpu7x-2x2x1-hbm.yaml`).
+
+## Configuration
+
+You can configure the behavior using the following environment variable:
+
+| Variable | Description | Required | Default |
+| :--- | :--- | :--- | :--- |
+| `GCS_BUCKET_ROOT_DIR` | The root GCS path where results will be stored. Must start with `gs://`. | **Yes** | `gs://example-microbenchmark` (Change this!) |
+
+## Usage Guide
+
+1.  **Clone the Repository**:
+    ```bash
+    git clone https://github.com/google/accelerator-microbenchmarks.git
+    cd accelerator-microbenchmarks
+    # Switch to the correct branch if necessary
+    git checkout tpu7x-auto
+    ```
+
+2.  **Set the GCS Bucket**:
+    Export the path to your GCS bucket. This is where all results will be saved.
+    ```bash
+    export GCS_BUCKET_ROOT_DIR="gs://your-unique-bucket-name/benchmark_runs/$(date +%Y%m%d_%H%M%S)"
+    ```
+
+3.  **Run the Automation Script**:
+    Execute the launch script from the root of the repository.
+    ```bash
+    bash Ironwood/guides/automation/automation_launch.sh
+    ```
+
+    **What happens next?**
+    *   The script validates your node pools.
+    *   It applies the Kueue job queues.
+    *   It submits the benchmark jobs defined in the script (e.g., HBM tests).
+    *   It waits for jobs to finish, retrying any failures up to 3 times.
+    *   Finally, it launches the `aggregator` job.
+
+## Output
+
+After the automation completes, check your GCS bucket (`GCS_BUCKET_ROOT_DIR`). You will find:
+
+*   **`aggregated_results/`**: Contains the final summary CSV/TSV files (e.g., `hbm.tsv`, `collectives.tsv`).
+*   **`<job-name>/`**: Directories for each individual job containing intermediate results.
+
+## Troubleshooting
+
+### Job Failures
+If jobs fail even after retries:
+1.  Check the script output to see which specific jobs failed.
+2.  Inspect the logs of a failed job using `kubectl logs job/<job-name>`.
+3.  Manually retry a specific job if needed using the command printed by the script at the end of the run.
+
+### Missing Results
+If the `aggregated_results` folder is empty:
+1.  Check the logs of the aggregator job:
+    ```bash
+    kubectl logs job/aggregator
+    ```
+2.  Ensure the `GCS_BUCKET_ROOT_DIR` was accessible by the pods (check Workload Identity or service account permissions if running in a restricted project).

--- a/microbenchmarks/ironwood/automation/aggregator.py
+++ b/microbenchmarks/ironwood/automation/aggregator.py
@@ -1,0 +1,176 @@
+import argparse
+import os
+import glob
+import pandas as pd
+import gcsfs
+
+columns_mapping = {
+    "collectives": [
+        "topology", "op_type", "input_num_elements", "transferred_data (GB)", "dtype", "step_time_ms_num_runs",
+        "achieved_bw (GB/s)_p50", "achieved_bw (GB/s)_p90", "achieved_bw (GB/s)_p95", "achieved_bw (GB/s)_p99", "achieved_bw (GB/s)_avg", "achieved_bw (GB/s)_min", "achieved_bw (GB/s)_max",
+        "step_time_ms_p50", "step_time_ms_p90", "step_time_ms_p95", "step_time_ms_p99", "step_time_ms_avg", "step_time_ms_min", "step_time_ms_max",
+    ],
+    "hbm": [
+        "dtype", "tensor_size_gbytes", "time_ms_num_runs",
+        "bw_gbyte_sec_p50", "bw_gbyte_sec_p90", "bw_gbyte_sec_p95", "bw_gbyte_sec_p99", "bw_gbyte_sec_avg", "bw_gbyte_sec_min", "bw_gbyte_sec_max",
+        "time_ms_p50", "time_ms_p90", "time_ms_p95", "time_ms_p99", "time_ms_avg", "time_ms_min", "time_ms_max",
+    ],
+    "host_device": [
+        "data_size_mib", "transfer_type", "H2D_bw (GiB/s)_num_runs",
+        "H2D_bw (GiB/s)_p50", "H2D_bw (GiB/s)_p90", "H2D_bw (GiB/s)_p95", "H2D_bw (GiB/s)_p99", 
+        "H2D_bw (GiB/s)_avg", "H2D_bw (GiB/s)_min", "H2D_bw (GiB/s)_max",
+        "D2H_bw (GiB/s)_p50", "D2H_bw (GiB/s)_p90", "D2H_bw (GiB/s)_p95", "D2H_bw (GiB/s)_p99", 
+        "D2H_bw (GiB/s)_avg", "D2H_bw (GiB/s)_min", "D2H_bw (GiB/s)_max",
+    ],
+    "gemm": [
+        "m", "n", "k", "dtype", "step_time_ms_num_runs",
+        "tflops_per_sec_per_device_p50", "tflops_per_sec_per_device_p90",
+        "tflops_per_sec_per_device_p95", "tflops_per_sec_per_device_p99",
+        "tflops_per_sec_per_device_avg", "tflops_per_sec_per_device_min",
+        "tflops_per_sec_per_device_max",
+        "step_time_ms_p50", "step_time_ms_p90", "step_time_ms_p95", "step_time_ms_p99", "step_time_ms_avg", "step_time_ms_min", "step_time_ms_max",
+    ],
+    "bmm": [
+        "b", "m", "n", "k", "dtype", "step_time_ms_num_runs",
+        "tflops_per_sec_per_device_p50", "tflops_per_sec_per_device_p90",
+        "tflops_per_sec_per_device_p95", "tflops_per_sec_per_device_p99",
+        "tflops_per_sec_per_device_avg", "tflops_per_sec_per_device_min",
+        "tflops_per_sec_per_device_max",
+        "step_time_ms_p50", "step_time_ms_p90", "step_time_ms_p95", "step_time_ms_p99", "step_time_ms_avg", "step_time_ms_min", "step_time_ms_max",
+    ],
+    "gemm_all_reduce": [
+        "topology", "m", "n", "k", "dtype", "step_time_ms_num_runs",
+        "tflops_per_sec_per_device_p50", "tflops_per_sec_per_device_p90",
+        "tflops_per_sec_per_device_p95", "tflops_per_sec_per_device_p99",
+        "tflops_per_sec_per_device_avg", "tflops_per_sec_per_device_min",
+        "tflops_per_sec_per_device_max",
+        "step_time_ms_p50", "step_time_ms_p90", "step_time_ms_p95", "step_time_ms_p99", "step_time_ms_avg", "step_time_ms_min", "step_time_ms_max",
+    ],
+    "attention": [
+        "batch_size", "q_seq_len", "kv_seq_len", "q_heads", "kv_heads", "qk_head_dim", "v_head_dim", "mode", "causal", "has_optimized", "time_ms_num_runs", 
+        "time_ms_p50", "time_ms_p90",
+        "time_ms_p95", "time_ms_p99",
+        "time_ms_avg", "time_ms_min",
+        "time_ms_max",
+    ],
+}
+
+def download_from_gcs(bucket_path: str, local_dir: str):
+    """
+    Downloads the content of the GCS bucket path to a local directory.
+    """
+    fs = gcsfs.GCSFileSystem()
+    gcs_path = bucket_path.replace("gs://", "").rstrip("/") + "/"
+
+    print(f"Downloading from gs://{gcs_path} to {local_dir}...")
+    os.makedirs(local_dir, exist_ok=True)
+    fs.get(gcs_path, local_dir, recursive=True)
+
+def aggregate_collectives(directories: list[str], picked_columns: list[str]) -> pd.DataFrame:
+    if len(directories) == 0:
+        return None
+    aggregated_df = pd.DataFrame()
+    for directory in directories:
+        files = glob.glob(f"{directory}/*.tsv")
+        for file in files:
+            df = pd.read_csv(file, sep='\t')
+            df["topology"] = [file.split('/')[-4].split('-')[1] for _ in range(df.shape[0])]
+            aggregated_df = pd.concat([aggregated_df, df[picked_columns].rename(columns={"step_time_ms_num_runs": "num_runs"})], ignore_index=True)
+    return aggregated_df
+
+def aggregate_hbm(directories: list[str], picked_columns: list[str]) -> pd.DataFrame:
+    if len(directories) == 0:
+        return None
+    aggregated_df = pd.DataFrame()
+    for directory in directories:
+        files = glob.glob(f"{directory}/*.tsv")
+        for file in files:
+            df = pd.read_csv(file, sep='\t')
+            aggregated_df = pd.concat([aggregated_df, df[picked_columns].rename(columns={"time_ms_num_runs": "num_runs"})], ignore_index=True)
+    return aggregated_df
+
+def aggregate_host_device(directories: list[str], picked_columns: list[str]) -> pd.DataFrame:
+    if len(directories) == 0:
+        return None
+    aggregated_df = pd.DataFrame()
+    for directory in directories:
+        files = glob.glob(f"{directory}/*.tsv")
+        for file in files:
+            df = pd.read_csv(file, sep='\t')
+            aggregated_df = pd.concat([aggregated_df, df[picked_columns].rename(columns={"H2D_bw (GiB/s)_num_runs": "num_runs"})], ignore_index=True)
+    return aggregated_df
+
+def aggregate_gemm(directories: list[str], picked_columns: list[str]) -> pd.DataFrame:
+    if len(directories) == 0:
+        return None
+    aggregated_df = pd.DataFrame()
+    for directory in directories:
+        files = glob.glob(f"{directory}/*.tsv")
+        for file in files:
+            df = pd.read_csv(file, sep='\t')
+            aggregated_df = pd.concat([aggregated_df, df[picked_columns].rename(columns={"step_time_ms_num_runs": "num_runs"})], ignore_index=True)
+    return aggregated_df
+
+def aggregate_gemm_all_reduce(directories: list[str], picked_columns: list[str]) -> pd.DataFrame:
+    if len(directories) == 0:
+        return None
+    aggregated_df = pd.DataFrame()
+    for directory in directories:
+        files = glob.glob(f"{directory}/*.tsv")
+        for file in files:
+            df = pd.read_csv(file, sep='\t')
+            df["topology"] = [file.split('/')[-4].split('-')[1] for _ in range(df.shape[0])]
+            aggregated_df = pd.concat([aggregated_df, df[picked_columns].rename(columns={"step_time_ms_num_runs": "num_runs"})], ignore_index=True)
+    return aggregated_df
+
+def aggregate_bmm(directories: list[str], picked_columns: list[str]) -> pd.DataFrame:
+    if len(directories) == 0:
+        return None
+    aggregated_df = pd.DataFrame()
+    for directory in directories:
+        files = glob.glob(f"{directory}/*.tsv")
+        for file in files:
+            df = pd.read_csv(file, sep='\t')
+            aggregated_df = pd.concat([aggregated_df, df[picked_columns].rename(columns={"step_time_ms_num_runs": "num_runs"})], ignore_index=True)
+    return aggregated_df
+
+def aggregate_attention(directories: list[str], picked_columns: list[str]) -> pd.DataFrame:
+    if len(directories) == 0:
+        return None
+    aggregated_df = pd.DataFrame()
+    for directory in directories:
+        files = glob.glob(f"{directory}/*.tsv")
+        for file in files:
+            df = pd.read_csv(file, sep='\t')
+            aggregated_df = pd.concat([aggregated_df, df[picked_columns].rename(columns={"step_time_ms_num_runs": "num_runs"})], ignore_index=True)
+    return aggregated_df
+
+aggregate_function = {
+    "collectives": aggregate_collectives,
+    "hbm": aggregate_hbm,
+    "host_device": aggregate_host_device,
+    "gemm": aggregate_gemm,
+    "bmm": aggregate_bmm,
+    "attention": aggregate_attention,
+    "gemm_all_reduce": aggregate_gemm_all_reduce,
+}
+
+def aggregate_results(bucket_path: str, local_dir: str):
+    categories = ["collectives", "hbm", "host_device", "gemm", "bmm", "gemm_all_reduce", "attention"]
+    directories = {}
+    results = {}
+    for category in categories:
+        directories[category] = sorted(glob.glob(f"{local_dir}/*/{category}/*", recursive=True))
+        results[category] = aggregate_function[category](directories[category], columns_mapping[category])
+        if results[category] is not None:
+            print(f"Writing {category} results to {bucket_path}/aggregated_results/{category}.tsv")
+            results[category].to_csv(f"{bucket_path}/aggregated_results/{category}.tsv", index=False, sep='\t')
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Download from GCS and aggregate results locally.")
+    parser.add_argument("--bucket_path", type=str, required=True, help="The GCS bucket path (gs://...)")
+    parser.add_argument("--local_dir", type=str, default="./results", help="Local directory to download and aggregate results.")
+    args = parser.parse_args()
+    
+    download_from_gcs(args.bucket_path, args.local_dir)
+    aggregate_results(args.bucket_path, args.local_dir)

--- a/microbenchmarks/ironwood/automation/aggregator.yaml
+++ b/microbenchmarks/ironwood/automation/aggregator.yaml
@@ -1,0 +1,25 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: aggregator
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      serviceAccountName: ${GCS_SA_NAME}
+      containers:
+      - name: main-app
+        image: python:3.12
+        command:
+        - bash
+        - -c
+        - |
+          set -ex
+          git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+          cd accelerator-microbenchmarks
+          git checkout tpu7x-auto
+          pip install gcsfs pandas
+
+          GCS_BUCKET_DIR=${GCS_BUCKET_ROOT_DIR}
+          python Ironwood/guides/automation/aggregator.py --bucket_path=${GCS_BUCKET_DIR}
+      restartPolicy: Never

--- a/microbenchmarks/ironwood/automation/automation_launch.sh
+++ b/microbenchmarks/ironwood/automation/automation_launch.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+
+######################################################################
+#                            USER INPUT
+######################################################################
+TIMESTAMP=$(date +%Y-%m-%d_%H-%M-%S)
+export GCS_BUCKET_ROOT_DIR=""
+export GCS_SA_NAME="gcs-writer"  # Service account with write access to GCS_BUCKET_ROOT_DIR
+export PROJECT_ID=$(gcloud config get-value project 2>/dev/null)
+
+MAX_RETRIES=3
+TIMEOUT_SECOND=7200
+
+yaml_names=(
+    "tpu7x-2x2x1-hbm.yaml"
+    "tpu7x-2x2x1-host_device.yaml"
+    "tpu7x-2x2x1-gemm_all_reduce.yaml"
+    "tpu7x-2x2x1-gemm.yaml"
+    "tpu7x-2x2x1-bmm.yaml"
+    "tpu7x-2x2x1-attention.yaml"
+    "tpu7x-2x2x1-collectives.yaml"
+    "tpu7x-2x2x2-collectives.yaml"
+    "tpu7x-2x2x4-collectives.yaml"
+    "tpu7x-2x4x4-collectives.yaml"
+    "tpu7x-4x4x4-collectives.yaml"
+    "tpu7x-4x4x4-gemm_all_reduce.yaml"
+)
+
+######################################################################
+#                        VALIDATION & SETUP
+######################################################################
+
+if [[ -z "${GCS_BUCKET_ROOT_DIR}" || "${GCS_BUCKET_ROOT_DIR}" != "gs://"* ]]; then
+  echo "Error: GCS_BUCKET_ROOT_DIR must be set and start with gs://"
+  exit 1
+fi
+
+echo "The intermediate result will be written to ${GCS_BUCKET_ROOT_DIR}"
+
+required_topologies=($(printf "%s\n" "${yaml_names[@]}" | grep -oE '[0-9]+x[0-9]+x[0-9]+' | sort -u))
+
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+if ! bash "${SCRIPT_DIR}/check_node_pool_setup.sh" "${required_topologies[@]}"; then
+  exit 1
+fi
+
+for topology in "${required_topologies[@]}"; do
+    export TOPOLOGY="${topology}"
+    export TPUS=$(echo "${TOPOLOGY}" | sed 's/x/*/g' | bc)
+    envsubst '${TOPOLOGY} ${TPUS}' < ${SCRIPT_DIR}/job-queue.yaml | kubectl apply -f -
+done
+
+######################################################################
+#                  GCS PERMISSION CHECK
+######################################################################
+
+# Run the GCS permission check
+export SA_NAME="${GCS_SA_NAME}"
+export PROJECT_ID="${PROJECT_ID}"
+if ! bash "${SCRIPT_DIR}/check_gcs_permissions.sh"; then
+    echo "GCS Permission Check Failed. Exiting."
+    exit 1
+fi
+
+
+######################################################################
+#                 LAUNCH JOBS & WAIT FOR COMPLETION
+######################################################################
+
+
+# Function to wait for a job to complete or fail
+wait_for_job_completion() {
+    local job_name="$1"
+    local timeout="$2"
+    local start_time=$(date +%s)
+    local end_time=$((start_time + timeout))
+
+    while true; do
+        current_time=$(date +%s)
+        if [[ $current_time -gt $end_time ]]; then
+            echo "Timeout waiting for job ${job_name}"
+            return 2
+        fi
+
+        # Check for Complete condition
+        if kubectl get job "${job_name}" -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' 2>/dev/null | grep -q "True"; then
+            echo "Job ${job_name} completed successfully!"
+            return 0
+        fi
+
+        # Check for Failed condition
+        if kubectl get job "${job_name}" -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null | grep -q "True"; then
+            echo "Job ${job_name} FAILED!"
+            return 1
+        fi
+
+        sleep 5
+    done
+}
+
+# Function to apply jobs and wait for them to complete
+# Returns a list of failed yaml files in the variable FAILED_JOBS
+apply_and_wait() {
+    local yaml_files=("$@")
+    local job_names_in_batch=()
+    FAILED_JOBS=()
+
+    echo "Processing batch of ${#yaml_files[@]} jobs..."
+
+    # Launch all jobs
+    for yaml_file in "${yaml_files[@]}"; do
+        local filepath="${SCRIPT_DIR}/${yaml_file}"
+        # Derive job name: remove .yaml, lowercase, replace _ with -
+        local job_name=$(basename "${yaml_file}" .yaml | tr '[:upper:]' '[:lower:]' | tr '_' '-')
+        random_suffix=$(head /dev/urandom | tr -dc a-z0-9 | head -c 5)
+        export JOB_NAME="${job_name}-${random_suffix}"
+        export GCS_PATH="${GCS_BUCKET_ROOT_DIR}/${job_name}"
+        
+        echo "Launching job: ${filepath} (name: ${JOB_NAME})"
+        envsubst '${JOB_NAME} ${GCS_PATH} ${GCS_SA_NAME}' < "${filepath}" | kubectl apply -f -
+        job_names_in_batch+=("${JOB_NAME}")
+    done
+
+    # Monitor jobs
+    local start_time=$(date +%s)
+    local end_time=$((start_time + TIMEOUT_SECOND))
+    local last_print_time=0
+    
+    while true; do
+        local current_time=$(date +%s)
+        if [[ $current_time -gt $end_time ]]; then
+            echo "Timeout waiting for batch completion"
+            break
+        fi
+
+        # Identify active jobs
+        local active_jobs=()
+        for job_name in "${job_names_in_batch[@]}"; do
+            # Check for Complete
+            if kubectl get job "${job_name}" -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' 2>/dev/null | grep -q "True"; then
+                continue
+            fi
+            
+            # Check for Failed
+            if kubectl get job "${job_name}" -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null | grep -q "True"; then
+                continue
+            fi
+            
+            # If neither, it's pending/running
+            active_jobs+=("${job_name}")
+        done
+
+        if [[ ${#active_jobs[@]} -eq 0 ]]; then
+            break
+        fi
+
+        # Dashboard View - Print every 60 seconds
+        if [[ $((current_time - last_print_time)) -ge 60 ]]; then
+            echo "======================================================================"
+            date "+%Y-%m-%d %H:%M:%S"
+            echo "----------------------------------------------------------------------"
+            kubectl get jobs "${active_jobs[@]}"
+            echo "======================================================================"
+            last_print_time=$current_time
+        fi
+        
+        sleep 10
+    done
+
+    # Collect results and cleanup
+    FAILED_JOBS=()
+    for i in "${!yaml_files[@]}"; do
+        local yaml_file="${yaml_files[$i]}"
+        local job_name="${job_names_in_batch[$i]}"
+        local filepath="${SCRIPT_DIR}/${yaml_file}"
+        
+        # Check if failed or still running (timeout)
+        if ! kubectl get job "${job_name}" -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' 2>/dev/null | grep -q "True"; then
+             FAILED_JOBS+=("${yaml_files[$i]}")
+        fi
+        
+        export JOB_NAME="${job_name}"
+        export GCS_PATH="${GCS_BUCKET_ROOT_DIR}/${job_name}"
+        envsubst '${JOB_NAME} ${GCS_PATH}' < "${filepath}" | kubectl delete -f - &> /dev/null
+    done
+}
+
+# Retry loop
+current_batch=("${yaml_names[@]}")
+
+for (( retry=1; retry<=MAX_RETRIES; retry++ )); do
+    apply_and_wait "${current_batch[@]}"
+
+    if [[ ${#FAILED_JOBS[@]} -eq 0 ]]; then
+        echo "All jobs completed successfully in Round ${retry}!"
+        break
+    fi
+
+    echo "Round ${retry} finished. ${#FAILED_JOBS[@]} jobs failed."
+    current_batch=("${FAILED_JOBS[@]}")
+
+    if [[ ${retry} -lt ${MAX_RETRIES} ]]; then
+        echo "Retrying failed jobs..."
+        echo "========================================"
+        echo "$((retry + 1)) / ${MAX_RETRIES}" max retries
+        echo "========================================"
+    else
+        echo "Max retries reached. ¯\_(ツ)_/¯"
+    fi
+done
+
+echo ""
+echo "Jobs completed. Aggregating results..."
+echo ""
+
+# Ensure cleanup of any previous aggregator job to avoid immutable field errors
+kubectl delete job aggregator --ignore-not-found=true
+
+envsubst '${GCS_BUCKET_ROOT_DIR} ${GCS_SA_NAME}' < ${SCRIPT_DIR}/aggregator.yaml | kubectl apply -f -
+wait_for_job_completion "aggregator" ${TIMEOUT_SECOND}
+envsubst '${GCS_BUCKET_ROOT_DIR} ${GCS_SA_NAME}' < ${SCRIPT_DIR}/aggregator.yaml | kubectl delete -f -
+
+# Print the failed jobs at the end for better visibility.
+
+if [[ ${#FAILED_JOBS[@]} -gt 0 ]]; then
+    echo "The following jobs finally failed after ${MAX_RETRIES} rounds:"
+    printf '%s\n' "${FAILED_JOBS[@]}"
+
+    echo -e "\nTo retry manually, run:"
+    for yaml_file in "${FAILED_JOBS[@]}"; do
+        job_name=$(basename "${yaml_file}" .yaml | tr '[:upper:]' '[:lower:]' | tr '_' '-')
+        GCS_PATH="${GCS_BUCKET_ROOT_DIR}/${job_name}"
+        echo "JOB_NAME=\"${job_name}\" GCS_PATH=\"${GCS_PATH}\" GCS_SA_NAME=\"${GCS_SA_NAME}\" envsubst '\${JOB_NAME} \${GCS_PATH} \${GCS_SA_NAME}' < \"${SCRIPT_DIR}/${yaml_file}\" | kubectl apply -f -"
+    done
+else
+    echo "Success! All jobs finished."
+fi

--- a/microbenchmarks/ironwood/automation/autoscaling/README.md
+++ b/microbenchmarks/ironwood/automation/autoscaling/README.md
@@ -1,0 +1,111 @@
+# Ironwood Benchmark Automation With CCC for nodepool creation
+
+This directory contains the automation framework for running TPU microbenchmarks (HBM, Host-Device, Collectives, etc.) on GKE clusters with autoscaling enabled through CCC. The tool simplifies the workflow of launching multiple benchmark jobs via [Kueue](https://kueue.sigs.k8s.io/), monitoring their status, handling retries, and aggregating the final results into a unified format.
+
+The autoscaling version of the script uses CustomComputeClass (CCC) to manage the creation and deletion of the required nodepools automatically based on the workloads.
+
+## Overview
+
+The automation workflow consists of three main stages:
+1.  **Launch**: Submits Kubernetes Jobs for various benchmark configurations (e.g., different topologies like 2x2x1, 2x2x2) using Kueue for queue management.
+2.  **Monitor & Retry**: Watches the jobs until completion. If any job fails, it automatically retries them (up to 3 times by default).
+3.  **Aggregate**: Once all jobs succeed, an aggregator job is launched to collect all intermediate results from GCS and consolidate them into summary TSV files.
+
+## Prerequisites
+
+Before running the automation script, ensure the following requirements are met:
+
+### 1. Environment Setup
+*   **GKE Cluster**: You must have a GKE cluster.
+*   **Kubectl**: Ensure `kubectl` is installed and authenticated to your cluster.
+*   **GCS Bucket**: A Google Cloud Storage bucket is required to store intermediate and final aggregated results.
+    ```bash
+    gcloud storage buckets create gs://my-unique-bucket-name --location=us-central1
+    ```
+
+### 2. Install Kueue
+The automation relies on Kueue for job queuing. Check if it's already installed:
+
+```bash
+kubectl get namespace kueue-system
+```
+
+If you see `Error from server (NotFound)`, install it with:
+
+```bash
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.16.0/manifests.yaml
+```
+
+### 3. Verify requirments for CCC
+In order for CCC to work the correct set of CCC templates need to be created. If you have not already done so, allowing pre-flight checks to run
+when the script prompts for it will install all the required CCC templates (templates for different TPU topologies 2x2x1, 2x2x2, etc)
+
+## Directory Structure
+
+*   `automation_launch.sh`: The main entry point script. Manages the full lifecycle of the benchmark run.
+*   `check_ccc_resources.sh`: Validation script that makes sure all CCC related resources are created.
+*   `create_ccc_templates.sh`: Create the required CCC related resources.
+*   `../aggregator.py`: Python script that downloads results from GCS and produces summary tables.
+*   `../aggregator.yaml`: Kubernetes Job definition for running the aggregator.
+*   `job-queue-CCC.yaml`: Kueue resource definitions (ClusterQueue, LocalQueue).
+*   `*.yaml`: Benchmark job configurations (e.g., `tpu7x-2x2x1-hbm.yaml`).
+
+## Configuration
+
+You can configure the behavior using the following environment variable:
+
+| Variable | Description | Required | Default |
+| :--- | :--- | :--- | :--- |
+| `GCS_BUCKET_ROOT_DIR` | The root GCS path where results will be stored. Must start with `gs://`. | **Yes** | `gs://example-microbenchmark` (Change this!) |
+
+## Usage Guide
+
+1.  **Clone the Repository**:
+    ```bash
+    git clone https://github.com/google/accelerator-microbenchmarks.git
+    cd accelerator-microbenchmarks
+    # Switch to the correct branch if necessary
+    git checkout tpu7x-auto
+    ```
+
+2.  **Set the GCS Bucket**:
+    Export the path to your GCS bucket. This is where all results will be saved.
+    ```bash
+    export GCS_BUCKET_ROOT_DIR="gs://your-unique-bucket-name/benchmark_runs/$(date +%Y%m%d_%H%M%S)"
+    ```
+
+3.  **Run the Automation Script**:
+    Execute the launch script from the root of the repository.
+    ```bash
+    bash Ironwood/guides/automation/automation_launch.sh
+    ```
+
+    **What happens next?**
+    *   If pre-flight checks are enabled, will check and CCC resources (and create if needed) and check GCS permissions
+    *   It applies the Kueue job queue.
+    *   It submits the benchmark jobs defined in the script (e.g., HBM tests).
+    *   It waits for jobs to finish, retrying any failures up to 3 times.
+    *   Finally, it launches the `aggregator` job.
+
+## Output
+
+After the automation completes, check your GCS bucket (`GCS_BUCKET_ROOT_DIR`). You will find:
+
+*   **`aggregated_results/`**: Contains the final summary CSV/TSV files (e.g., `hbm.tsv`, `collectives.tsv`).
+*   **`<job-name>/`**: Directories for each individual job containing intermediate results.
+
+## Troubleshooting
+
+### Job Failures
+If jobs fail even after retries:
+1.  Check the script output to see which specific jobs failed.
+2.  Inspect the logs of a failed job using `kubectl logs job/<job-name>`.
+3.  Manually retry a specific job if needed using the command printed by the script at the end of the run.
+
+### Missing Results
+If the `aggregated_results` folder is empty:
+1.  Check the logs of the aggregator job:
+    ```bash
+    kubectl logs job/aggregator
+    ```
+2.  Ensure the `GCS_BUCKET_ROOT_DIR` was accessible by the pods (check Workload Identity or service account permissions if running in a restricted project).

--- a/microbenchmarks/ironwood/automation/autoscaling/automation_launch.sh
+++ b/microbenchmarks/ironwood/automation/autoscaling/automation_launch.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+
+######################################################################
+# automation_launch.sh: Run a series of TPU microbenchmark jobs
+######################################################################
+# This script automates the process of launching multiple TPU microbenchmark
+# jobs defined in various YAML files. It handles:
+#   - Pre-flight checks for necessary CCC resources and GCS permissions.
+#   - Applying job YAMLs to a Kubernetes cluster.
+#   - Waiting for jobs to complete, with a timeout.
+#   - Retrying failed jobs up to a configurable number of times.
+#   - Aggregating results using a separate aggregator job.
+#   - Reporting on any jobs that ultimately failed.
+#
+# User-configurable variables are at the top of the script.
+######################################################################
+
+######################################################################
+#                            USER INPUT
+######################################################################
+TIMESTAMP=$(date +%Y-%m-%d_%H-%M-%S)
+export GCS_BUCKET_ROOT_DIR="gs://<BUCKET_NAME>/<FOLDER_NAME>"
+export GCS_SA_NAME="gcs-writer"  # Service account with write access to GCS_BUCKET_ROOT_DIR
+export PROJECT_ID=$(gcloud config get-value project 2>/dev/null)
+MAX_RETRIES=3
+TIMEOUT_SECOND=3600
+
+yaml_names=(
+    "tpu7x-2x2x1-bmm.yaml"
+    "tpu7x-2x2x1-collectives.yaml"
+    "tpu7x-2x2x1-gemm.yaml"
+    "tpu7x-2x2x1-gemm_all_reduce.yaml"
+    "tpu7x-2x2x1-hbm.yaml"
+    "tpu7x-2x2x1-host_device.yaml"
+    "tpu7x-2x2x2-collectives.yaml"
+    "tpu7x-2x2x4-collectives.yaml"
+    "tpu7x-2x4x4-collectives.yaml"
+    "tpu7x-4x4x4-collectives.yaml"
+    "tpu7x-4x4x8-collectives.yaml"
+)
+
+################################################################################
+# COLOR OUTPUT
+################################################################################
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+function print_success() {
+    echo -e "${GREEN}✅ $1${NC}"
+}
+
+function print_error() {
+    echo -e "${RED}❌ $1${NC}"
+}
+
+function print_info() {
+    echo -e "${BLUE}ℹ️  $1${NC}"
+}
+
+function print_warning() {
+    echo -e "${YELLOW}⚠️  $1${NC}"
+}
+
+######################################################################
+#                        VALIDATION & SETUP
+######################################################################
+
+if [[ -z "${GCS_BUCKET_ROOT_DIR}" || "${GCS_BUCKET_ROOT_DIR}" != "gs://"* ]]; then
+  print_error "GCS_BUCKET_ROOT_DIR must be set and start with gs://"
+  exit 1
+fi
+
+print_info "The intermediate result will be written to ${GCS_BUCKET_ROOT_DIR}"
+
+read -p "Run pre-flight checks (CCC resource validation & GCS permissions)? (y/n): " run_checks
+
+if [[ "$run_checks" == "y" ]]; then
+  print_info "Running CCC resource validation..."
+  required_topologies=($(printf "%s\n" "${yaml_names[@]}" | grep -oE '[0-9]+x[0-9]+x[0-9]+' | sort -u))
+  SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+  if ! bash "${SCRIPT_DIR}/check_ccc_resources.sh"; then
+    print_error "Some required CCC resources are missing. Please run create_ccc_templates.sh first. Make sure to fill the requierd variables."
+    exit 1
+  fi
+
+  print_info "Running GCS permission check..."
+  export SA_NAME="${GCS_SA_NAME}"
+  export PROJECT_ID="${PROJECT_ID}"
+  if ! bash "${SCRIPT_DIR}/../check_gcs_permissions.sh"; then
+      print_error "GCS Permission Check Failed. Exiting."
+      exit 1
+  fi
+else
+  print_warning "Skipping pre-flight checks."
+fi
+
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+kubectl apply -f ${SCRIPT_DIR}/job-queue-CCC.yaml
+
+######################################################################
+#                 LAUNCH JOBS & WAIT FOR COMPLETION
+######################################################################
+
+
+# Function to wait for a job to complete or fail
+wait_for_job_completion() {
+    local job_name="$1"
+    local timeout="$2"
+    local start_time=$(date +%s)
+    local end_time=$((start_time + timeout))
+
+    while true; do
+        current_time=$(date +%s)
+        if [[ $current_time -gt $end_time ]]; then
+            print_error "Timeout waiting for job ${job_name}"
+            return 2
+        fi
+
+        # Check for Complete condition
+        if kubectl get job "${job_name}" -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' 2>/dev/null | grep -q "True"; then
+            print_success "Job ${job_name} completed successfully!"
+            return 0
+        fi
+
+        # Check for Failed condition
+        if kubectl get job "${job_name}" -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null | grep -q "True"; then
+            print_error "Job ${job_name} FAILED!"
+            return 1
+        fi
+
+        sleep 5
+    done
+}
+
+# Function to apply jobs and wait for them to complete
+# Returns a list of failed yaml files in the variable FAILED_JOBS
+apply_and_wait() {
+    local yaml_files=("$@")
+    local job_names_in_batch=()
+    FAILED_JOBS=()
+
+    print_info "Processing batch of ${#yaml_files[@]} jobs..."
+
+    # Launch all jobs
+    for yaml_file in "${yaml_files[@]}"; do
+        local filepath="${SCRIPT_DIR}/${yaml_file}"
+        # Derive job name: remove .yaml, lowercase, replace _ with -
+        local job_name=$(basename "${yaml_file}" .yaml | tr '[:upper:]' '[:lower:]' | tr '_' '-')
+        random_suffix=$(head /dev/urandom | tr -dc a-z0-9 | head -c 5)
+        export JOB_NAME="${job_name}-${random_suffix}"
+        export GCS_PATH="${GCS_BUCKET_ROOT_DIR}/${job_name}"
+        
+        print_info "Launching job: ${filepath} (name: ${JOB_NAME})"
+        envsubst '${JOB_NAME} ${GCS_PATH} ${GCS_SA_NAME}' < "${filepath}" | kubectl apply -f -
+        job_names_in_batch+=("${JOB_NAME}")
+    done
+
+    # Monitor jobs
+    local start_time=$(date +%s)
+    local end_time=$((start_time + TIMEOUT_SECOND))
+    local last_print_time=0
+    
+    while true; do
+        local current_time=$(date +%s)
+        if [[ $current_time -gt $end_time ]]; then
+            print_error "Timeout waiting for batch completion"
+            break
+        fi
+
+        # Identify active jobs
+        local active_jobs=()
+        for job_name in "${job_names_in_batch[@]}"; do
+            # Check for Complete
+            if kubectl get job "${job_name}" -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' 2>/dev/null | grep -q "True"; then
+                continue
+            fi
+            
+            # Check for Failed
+            if kubectl get job "${job_name}" -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null | grep -q "True"; then
+                continue
+            fi
+            
+            # If neither, it's pending/running
+            active_jobs+=("${job_name}")
+        done
+
+        if [[ ${#active_jobs[@]} -eq 0 ]]; then
+            break
+        fi
+
+        # Dashboard View - Print every 60 seconds
+        if [[ $((current_time - last_print_time)) -ge 60 ]]; then
+            print_info "======================================================================"
+            date "+%Y-%m-%d %H:%M:%S"
+            print_info "----------------------------------------------------------------------"
+            kubectl get jobs "${active_jobs[@]}"
+            print_info "======================================================================"
+            last_print_time=$current_time
+        fi
+        
+        sleep 10
+    done
+
+    # Collect results and cleanup
+    FAILED_JOBS=()
+    for i in "${!yaml_files[@]}"; do
+        local yaml_file="${yaml_files[$i]}"
+        local job_name="${job_names_in_batch[$i]}"
+        local filepath="${SCRIPT_DIR}/${yaml_file}"
+        
+        # Check if failed or still running (timeout)
+        if ! kubectl get job "${job_name}" -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' 2>/dev/null | grep -q "True"; then
+             FAILED_JOBS+=("${yaml_files[$i]}")
+        fi
+        
+        export JOB_NAME="${job_name}"
+        export GCS_PATH="${GCS_BUCKET_ROOT_DIR}/${job_name}"
+        envsubst '${JOB_NAME} ${GCS_PATH}' < "${filepath}" | kubectl delete -f - &> /dev/null
+    done
+}
+
+# Retry loop
+current_batch=("${yaml_names[@]}")
+
+for (( retry=1; retry<=MAX_RETRIES; retry++ )); do
+    apply_and_wait "${current_batch[@]}"
+
+    if [[ ${#FAILED_JOBS[@]} -eq 0 ]]; then
+        print_success "All jobs completed successfully in Round ${retry}!"
+        break
+    fi
+
+    print_error "Round ${retry} finished. ${#FAILED_JOBS[@]} jobs failed."
+    current_batch=("${FAILED_JOBS[@]}")
+
+    if [[ ${retry} -lt ${MAX_RETRIES} ]]; then
+        print_info "Retrying failed jobs..."
+        print_info "========================================"
+        print_info "$((retry + 1)) / ${MAX_RETRIES} max retries"
+        print_info "========================================"
+    else
+        print_error "Max retries reached."
+    fi
+done
+
+echo ""
+print_info "Jobs completed. Aggregating results..."
+echo ""
+
+# Ensure cleanup of any previous aggregator job to avoid immutable field errors
+kubectl delete job aggregator --ignore-not-found=true
+
+envsubst '${GCS_BUCKET_ROOT_DIR} ${GCS_SA_NAME}' < ${SCRIPT_DIR}/../aggregator.yaml | kubectl apply -f -
+wait_for_job_completion "aggregator" ${TIMEOUT_SECOND}
+envsubst '${GCS_BUCKET_ROOT_DIR} ${GCS_SA_NAME}' < ${SCRIPT_DIR}/../aggregator.yaml | kubectl delete -f -
+
+# Print the failed jobs at the end for better visibility.
+
+if [[ ${#FAILED_JOBS[@]} -gt 0 ]]; then
+    print_error "The following jobs finally failed after ${MAX_RETRIES} rounds:"
+    printf '%s\n' "${FAILED_JOBS[@]}"
+
+    echo -e "\nTo retry manually, run:"
+    for yaml_file in "${FAILED_JOBS[@]}"; do
+        job_name=$(basename "${yaml_file}" .yaml | tr '[:upper:]' '[:lower:]' | tr '_' '-')
+        GCS_PATH="${GCS_BUCKET_ROOT_DIR}/${job_name}"
+        echo "JOB_NAME=\"${job_name}\" GCS_PATH=\"${GCS_PATH}\" envsubst '\${JOB_NAME} \${GCS_PATH}' < \"${SCRIPT_DIR}/${yaml_file}\" | kubectl apply -f -"
+    done
+else
+    print_success "Success! All jobs finished."
+fi

--- a/microbenchmarks/ironwood/automation/autoscaling/check_ccc_resources.sh
+++ b/microbenchmarks/ironwood/automation/autoscaling/check_ccc_resources.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+######################################################################
+# check_ccc_resources.sh: Validate existence of CCC resources
+######################################################################
+# This script checks if the required Google Cloud Compute resource policies
+# and Kubernetes Custom Compute Class (CCC) manifests exist for a given
+# list of TPU topologies.
+#
+# It iterates through the provided TOPOLOGIES array:
+#   - For multi-host topologies, it verifies the presence of the
+#     expected workload policy using gcloud.
+#   - It checks for the existence of the Custom Compute Class resource
+#     in the Kubernetes cluster using kubectl.
+#
+# The script exits with status 1 if any required resource is missing,
+# and status 0 if all resources are found.
+######################################################################
+
+export TOPOLOGIES=(2x2x1 2x2x2 2x2x4 2x4x4 4x4x4 4x4x8)
+PROJECT_ID="${PROJECT_ID:-$(gcloud config get-value project 2>/dev/null)}"
+export REGION=$(kubectl get nodes -o jsonpath='{.items[0].metadata.labels.topology\.kubernetes\.io/region}')
+CLUSTER_NAME=$(kubectl config current-context | cut -d '_' -f 4)
+export RESOURCE_NAME=${CLUSTER_NAME%-gke}
+
+################################################################################
+# COLOR OUTPUT
+################################################################################
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+function print_success() {
+    echo -e "${GREEN}✅ $1${NC}"
+}
+
+function print_error() {
+    echo -e "${RED}❌ $1${NC}"
+}
+
+function print_info() {
+    echo -e "${BLUE}ℹ️  $1${NC}"
+}
+
+print_info "Checking CCC resources for all topologies"
+missing_resources=false
+
+for TOPOLOGY in "${TOPOLOGIES[@]}"
+do
+    print_info "Checking resources for topology: ${TOPOLOGY}"
+    # Check workload policy for multi-host topologies
+    if [[ "${TOPOLOGY}" != "2x2x1" ]]; then
+        WORKLOAD_POLICY_NAME="${RESOURCE_NAME}-workload-policy${TOPOLOGY}"
+        if gcloud compute resource-policies describe ${WORKLOAD_POLICY_NAME} --project=${PROJECT_ID} --region=${REGION} &> /dev/null; then
+            print_success "Workload policy ${WORKLOAD_POLICY_NAME} exists."
+        else
+            print_error "Workload policy ${WORKLOAD_POLICY_NAME} is MISSING."
+            missing_resources=true
+        fi
+    else
+        print_info "Skipping workload policy check for single-host topology ${TOPOLOGY}."
+    fi
+
+    # Check Custom Compute Class
+    CCC_NAME="tpuv7-${TOPOLOGY}-class"
+    if kubectl get computeclass ${CCC_NAME} &> /dev/null; then
+        print_success "Custom Compute Class ${CCC_NAME} exists."
+    else
+        print_error "Custom Compute Class ${CCC_NAME} is MISSING."
+        missing_resources=true
+    fi
+done
+
+if [[ "${missing_resources}" == "true" ]]; then
+    print_error "One or more required resources are missing. Please create them."
+    exit 1
+else
+    print_success "All required CCC resources exist."
+    exit 0
+fi

--- a/microbenchmarks/ironwood/automation/autoscaling/create_ccc_templates.sh
+++ b/microbenchmarks/ironwood/automation/autoscaling/create_ccc_templates.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+######################################################################
+# create_ccc_templates.sh: Create Custom Compute Class templates
+######################################################################
+# This script creates the necessary Google Cloud Compute resource policies
+# and Kubernetes Custom Compute Class (CCC) manifests for various TPU
+# topologies.
+#
+# It iterates through a predefined list of TOPOLOGIES:
+#   - For multi-host topologies, it creates a HIGH_THROUGHPUT
+#     workload policy if it doesn't already exist.
+#   - It then uses envsubst to populate a template YAML
+#     (tpu-ccc-template.yaml) with the correct TPU_TOPOLOGY,
+#     RESERVATION_NAME, PROJECT_ID, and POLICY_NAME.
+#   - The resulting manifest is applied to the Kubernetes cluster using
+#     kubectl apply.
+#
+# Required environment variables:
+#   - RESERVATION_NAME: The name of the GCE reservation to use.
+#   - PROJECT_ID: The Google Cloud Project ID.
+#   - REGION: The Google Cloud Region.
+#   - RESOURCE_NAME: A base name used for naming resources.
+######################################################################
+
+export RESERVATION_NAME="<RESERVATION_NAME>"
+
+
+export TOPOLOGIES=(2x2x1 2x2x2 2x2x4 2x4x4 4x4x4 4x4x8)
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+PROJECT_ID="${PROJECT_ID:-$(gcloud config get-value project 2>/dev/null)}"
+export REGION=$(kubectl get nodes -o jsonpath='{.items[0].metadata.labels.topology\.kubernetes\.io/region}')
+CLUSTER_NAME=$(kubectl config current-context | cut -d '_' -f 4)
+export RESOURCE_NAME=${CLUSTER_NAME%-gke} # assumes cluster was created with setup script which creates cluster with ${RESOURCE_NAME}-gke as name
+################################################################################
+# COLOR OUTPUT
+################################################################################
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+function print_header() {
+    echo -e "\n${BLUE}========================================${NC}"
+    echo -e "${BLUE}$1${NC}"
+    echo -e "${BLUE}========================================${NC}\n"
+}
+
+function print_success() {
+    echo -e "${GREEN}✅ $1${NC}"
+}
+
+function print_error() {
+    echo -e "${RED}❌ $1${NC}"
+}
+
+function print_warning() {
+    echo -e "${YELLOW}⚠️  $1${NC}"
+}
+
+function print_info() {
+    echo -e "${BLUE}ℹ️  $1${NC}"
+}
+
+print_info "Creating CCC templates for all topoligies"
+# Create workload policy
+for TOPOLOGY in "${TOPOLOGIES[@]}"
+do
+    export TPU_TOPOLOGY=${TOPOLOGY}
+    if [[ "${TOPOLOGY}" == "2x2x1" ]]; then
+        print_warning "Skipping workload policy creation for ${TOPOLOGY} as it is not needed for single host topologies."
+        export POLICY_NAME="" # No policy for single host
+    else
+        WORKLOAD_POLICY_NAME="${RESOURCE_NAME}-workload-policy${TOPOLOGY}"
+        if gcloud compute resource-policies describe ${WORKLOAD_POLICY_NAME} --project=${PROJECT_ID} --region=${REGION} &> /dev/null; then
+            print_info "Workload policy ${WORKLOAD_POLICY_NAME} already exists."
+        else
+            print_info "Creating workload policy ${WORKLOAD_POLICY_NAME}..."
+            gcloud compute resource-policies create workload-policy ${WORKLOAD_POLICY_NAME} \
+    --type HIGH_THROUGHPUT \
+    --accelerator-topology ${TOPOLOGY} \
+    --project ${PROJECT_ID} \
+    --region ${REGION}
+            print_success "Workload policy ${WORKLOAD_POLICY_NAME} created."
+        fi
+        export POLICY_NAME=${WORKLOAD_POLICY_NAME}
+    fi
+
+    echo "${TPU_TOPOLOGY} ${RESERVATION_NAME} ${PROJECT_ID} ${POLICY_NAME}"
+    if [[ "${TOPOLOGY}" == "2x2x1" ]]; then
+        envsubst '${TPU_TOPOLOGY} ${RESERVATION_NAME} ${PROJECT_ID}' < ${SCRIPT_DIR}/tpu-ccc-template.yaml | sed '/placement:/,/policyName:/d' | kubectl apply -f -
+    else
+        envsubst '${TPU_TOPOLOGY} ${RESERVATION_NAME} ${PROJECT_ID} ${POLICY_NAME}' < ${SCRIPT_DIR}/tpu-ccc-template.yaml | kubectl apply -f -
+    fi
+    print_success "Applied TPU Compute Class for ${TOPOLOGY}"
+done

--- a/microbenchmarks/ironwood/automation/autoscaling/job-queue-CCC.yaml
+++ b/microbenchmarks/ironwood/automation/autoscaling/job-queue-CCC.yaml
@@ -1,0 +1,40 @@
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  name: "flavor-tpu7x"
+spec:
+  nodeLabels:
+    cloud.google.com/gke-tpu-accelerator: tpu7x
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: cluster-queue-tpu7x
+spec:
+  flavorFungibility:
+    whenCanBorrow: MayStopSearch
+    whenCanPreempt: TryNextFlavor
+  namespaceSelector: {}
+  preemption:
+    borrowWithinCohort:
+      policy: Never
+    reclaimWithinCohort: Never
+    withinClusterQueue: LowerPriority
+  queueingStrategy: BestEffortFIFO
+  resourceGroups:
+  - coveredResources:
+    - google.com/tpu
+    flavors:
+    - name: flavor-tpu7x
+      resources:
+      - name: google.com/tpu
+        nominalQuota: 128
+  stopPolicy: None
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata:
+  namespace: default
+  name: "user-queue-tpu7x"
+spec:
+  clusterQueue: "cluster-queue-tpu7x"

--- a/microbenchmarks/ironwood/automation/autoscaling/tpu-ccc-template.yaml
+++ b/microbenchmarks/ironwood/automation/autoscaling/tpu-ccc-template.yaml
@@ -1,0 +1,19 @@
+apiVersion: cloud.google.com/v1
+kind: ComputeClass
+metadata:
+  name: tpuv7-${TPU_TOPOLOGY}-class
+spec:
+  priorities:
+    - tpu:
+        type: tpu7x
+        topology: ${TPU_TOPOLOGY}
+        count: 4
+      reservations:
+        specific:
+        - name: ${RESERVATION_NAME}
+          project: ${PROJECT_ID}
+        affinity: Specific
+      placement:
+        policyName: ${POLICY_NAME}
+  nodePoolAutoCreation:
+    enabled: true

--- a/microbenchmarks/ironwood/automation/autoscaling/tpu7x-2x2x1-bmm.yaml
+++ b/microbenchmarks/ironwood/automation/autoscaling/tpu7x-2x2x1-bmm.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-svc-${JOB_NAME}
+spec:
+  clusterIP: None
+  selector:
+    job-name: ${JOB_NAME}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue-tpu7x
+spec:
+  completionMode: Indexed
+  suspend: true
+  parallelism: 1
+  completions: 1
+  backoffLimit: 0
+  template:
+    spec:
+      subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
+      restartPolicy: Never
+      nodeSelector:
+        cloud.google.com/compute-class: tpuv7-2x2x1-class
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 2x2x1
+      containers:
+      - name: jax-tpu
+        image: python:3.12
+        securityContext:
+          privileged: false
+        env:
+        - name: JAX_PLATFORMS
+          value: "tpu,cpu"
+        - name: TPU_VMODULE
+          value: "singleton_tpu_system_manager=10,tpu_version_flag=10,device_util=10,device_scanner=10,mesh_builder=10,master=10"
+        - name: XLA_IR_DEBUG
+          value: "1"
+        - name: XLA_HLO_DEBUG
+          value: "1"
+        command:
+        - bash
+        - -c
+        - |
+          set -ex
+
+          git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+          cd accelerator-microbenchmarks
+          git checkout tpu7x-auto
+          pip install -r requirements.txt
+
+          GCS_BUCKET_DIR=${GCS_PATH}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/bmm/single_device_bmm.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+        resources:
+          requests:
+            google.com/tpu: 4
+          limits:
+            google.com/tpu: 4

--- a/microbenchmarks/ironwood/automation/autoscaling/tpu7x-2x2x1-collectives.yaml
+++ b/microbenchmarks/ironwood/automation/autoscaling/tpu7x-2x2x1-collectives.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-svc-${JOB_NAME}
+spec:
+  clusterIP: None
+  selector:
+    job-name: ${JOB_NAME}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue-tpu7x
+spec:
+  completionMode: Indexed
+  suspend: true
+  parallelism: 1
+  completions: 1
+  backoffLimit: 0
+  template:
+    spec:
+      subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
+      restartPolicy: Never
+      nodeSelector:
+        cloud.google.com/compute-class: tpuv7-2x2x1-class
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 2x2x1
+      containers:
+      - name: jax-tpu
+        image: python:3.12
+        securityContext:
+          privileged: false
+        env:
+        - name: JAX_PLATFORMS
+          value: "tpu,cpu"
+        - name: TPU_VMODULE
+          value: "singleton_tpu_system_manager=10,tpu_version_flag=10,device_util=10,device_scanner=10,mesh_builder=10,master=10"
+        - name: XLA_IR_DEBUG
+          value: "1"
+        - name: XLA_HLO_DEBUG
+          value: "1"
+        command:
+        - bash
+        - -c
+        - |
+          set -ex
+
+          git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+          cd accelerator-microbenchmarks
+          git checkout tpu7x-auto
+          pip install -r requirements.txt
+
+          GCS_BUCKET_DIR=${GCS_PATH}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_gather_tpu7x_2x2x1.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_reduce_tpu7x_2x2x1.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_to_all_tpu7x_2x2x1.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+        resources:
+          requests:
+            google.com/tpu: 4
+          limits:
+            google.com/tpu: 4

--- a/microbenchmarks/ironwood/automation/autoscaling/tpu7x-2x2x1-gemm.yaml
+++ b/microbenchmarks/ironwood/automation/autoscaling/tpu7x-2x2x1-gemm.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-svc-${JOB_NAME}
+spec:
+  clusterIP: None
+  selector:
+    job-name: ${JOB_NAME}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue-tpu7x
+spec:
+  completionMode: Indexed
+  suspend: true
+  parallelism: 1
+  completions: 1
+  backoffLimit: 0
+  template:
+    spec:
+      subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
+      restartPolicy: Never
+      nodeSelector:
+        cloud.google.com/compute-class: tpuv7-2x2x1-class
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 2x2x1
+      containers:
+      - name: jax-tpu
+        image: python:3.12
+        securityContext:
+          privileged: false
+        env:
+        - name: JAX_PLATFORMS
+          value: "tpu,cpu"
+        - name: TPU_VMODULE
+          value: "singleton_tpu_system_manager=10,tpu_version_flag=10,device_util=10,device_scanner=10,mesh_builder=10,master=10"
+        - name: XLA_IR_DEBUG
+          value: "1"
+        - name: XLA_HLO_DEBUG
+          value: "1"
+        command:
+        - bash
+        - -c
+        - |
+          set -ex
+
+          git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+          cd accelerator-microbenchmarks
+          git checkout tpu7x-auto
+          pip install -r requirements.txt
+
+          GCS_BUCKET_DIR=${GCS_PATH}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/gemm/gemm_multiple_run_more.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+        resources:
+          requests:
+            google.com/tpu: 4
+          limits:
+            google.com/tpu: 4

--- a/microbenchmarks/ironwood/automation/autoscaling/tpu7x-2x2x1-gemm_all_reduce.yaml
+++ b/microbenchmarks/ironwood/automation/autoscaling/tpu7x-2x2x1-gemm_all_reduce.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-svc-${JOB_NAME}
+spec:
+  clusterIP: None
+  selector:
+    job-name: ${JOB_NAME}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue-tpu7x
+spec:
+  completionMode: Indexed
+  suspend: true
+  parallelism: 1
+  completions: 1
+  backoffLimit: 0
+  template:
+    spec:
+      subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
+      restartPolicy: Never
+      nodeSelector:
+        cloud.google.com/compute-class: tpuv7-2x2x1-class
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 2x2x1
+      containers:
+      - name: jax-tpu
+        image: python:3.12
+        securityContext:
+          privileged: false
+        env:
+        - name: JAX_PLATFORMS
+          value: "tpu,cpu"
+        - name: TPU_VMODULE
+          value: "singleton_tpu_system_manager=10,tpu_version_flag=10,device_util=10,device_scanner=10,mesh_builder=10,master=10"
+        - name: XLA_IR_DEBUG
+          value: "1"
+        - name: XLA_HLO_DEBUG
+          value: "1"
+        command:
+        - bash
+        - -c
+        - |
+          set -ex
+
+          git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+          cd accelerator-microbenchmarks
+          git checkout tpu7x-auto
+          pip install -r requirements.txt
+
+          GCS_BUCKET_DIR=${GCS_PATH}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/gemm_all_reduce/gemm_all_reduce.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+        resources:
+          requests:
+            google.com/tpu: 4
+          limits:
+            google.com/tpu: 4

--- a/microbenchmarks/ironwood/automation/autoscaling/tpu7x-2x2x1-hbm.yaml
+++ b/microbenchmarks/ironwood/automation/autoscaling/tpu7x-2x2x1-hbm.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-svc-${JOB_NAME}
+spec:
+  clusterIP: None
+  selector:
+    job-name: ${JOB_NAME}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue-tpu7x
+spec:
+  completionMode: Indexed
+  suspend: true
+  parallelism: 1
+  completions: 1
+  backoffLimit: 0
+  template:
+    spec:
+      subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
+      restartPolicy: Never
+      nodeSelector:
+        cloud.google.com/compute-class: tpuv7-2x2x1-class
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 2x2x1
+      containers:
+      - name: jax-tpu
+        image: python:3.12
+        securityContext:
+          privileged: false
+        env:
+        - name: JAX_PLATFORMS
+          value: "tpu,cpu"
+        - name: TPU_VMODULE
+          value: "singleton_tpu_system_manager=10,tpu_version_flag=10,device_util=10,device_scanner=10,mesh_builder=10,master=10"
+        - name: XLA_IR_DEBUG
+          value: "1"
+        - name: XLA_HLO_DEBUG
+          value: "1"
+        command:
+        - bash
+        - -c
+        - |
+          set -ex
+
+          git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+          cd accelerator-microbenchmarks
+          git checkout tpu7x-auto
+          pip install -r requirements.txt
+
+          GCS_BUCKET_DIR=${GCS_PATH}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/hbm/hbm.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+        resources:
+          requests:
+            google.com/tpu: 4
+          limits:
+            google.com/tpu: 4

--- a/microbenchmarks/ironwood/automation/autoscaling/tpu7x-2x2x1-host_device.yaml
+++ b/microbenchmarks/ironwood/automation/autoscaling/tpu7x-2x2x1-host_device.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-svc-${JOB_NAME}
+spec:
+  clusterIP: None
+  selector:
+    job-name: ${JOB_NAME}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue-tpu7x
+spec:
+  completionMode: Indexed
+  suspend: true
+  parallelism: 1
+  completions: 1
+  backoffLimit: 0
+  template:
+    spec:
+      subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
+      restartPolicy: Never
+      nodeSelector:
+        cloud.google.com/compute-class: tpuv7-2x2x1-class
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 2x2x1
+      containers:
+      - name: jax-tpu
+        image: python:3.12
+        securityContext:
+          privileged: false
+        env:
+        - name: JAX_PLATFORMS
+          value: "tpu,cpu"
+        - name: TPU_VMODULE
+          value: "singleton_tpu_system_manager=10,tpu_version_flag=10,device_util=10,device_scanner=10,mesh_builder=10,master=10"
+        - name: XLA_IR_DEBUG
+          value: "1"
+        - name: XLA_HLO_DEBUG
+          value: "1"
+        command:
+        - bash
+        - -c
+        - |
+          set -ex
+
+          git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+          cd accelerator-microbenchmarks
+          git checkout tpu7x-auto
+          pip install -r requirements.txt
+
+          GCS_BUCKET_DIR=${GCS_PATH}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/host_device/host_device.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+        resources:
+          requests:
+            google.com/tpu: 4
+          limits:
+            google.com/tpu: 4

--- a/microbenchmarks/ironwood/automation/autoscaling/tpu7x-2x2x2-collectives.yaml
+++ b/microbenchmarks/ironwood/automation/autoscaling/tpu7x-2x2x2-collectives.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-svc-${JOB_NAME}
+spec:
+  clusterIP: None
+  selector:
+    job-name: ${JOB_NAME}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue-tpu7x
+spec:
+  completionMode: Indexed
+  suspend: true
+  parallelism: 2
+  completions: 2
+  backoffLimit: 0
+  template:
+    spec:
+      subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
+      restartPolicy: Never
+      nodeSelector:
+        cloud.google.com/compute-class: tpuv7-2x2x2-class
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 2x2x2
+      containers:
+      - name: jax-tpu
+        image: python:3.12
+        securityContext:
+          privileged: false
+        env:
+        - name: JAX_PLATFORMS
+          value: "tpu,cpu"
+        - name: TPU_VMODULE
+          value: "singleton_tpu_system_manager=10,tpu_version_flag=10,device_util=10,device_scanner=10,mesh_builder=10,master=10"
+        - name: XLA_IR_DEBUG
+          value: "1"
+        - name: XLA_HLO_DEBUG
+          value: "1"
+        command:
+        - bash
+        - -c
+        - |
+          set -ex
+
+          git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+          cd accelerator-microbenchmarks
+          git checkout tpu7x-auto
+          pip install -r requirements.txt
+
+          GCS_BUCKET_DIR=${GCS_PATH}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_gather_tpu7x_2x2x2.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_reduce_tpu7x_2x2x2.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_to_all_tpu7x_2x2x2.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+        resources:
+          requests:
+            google.com/tpu: 4
+          limits:
+            google.com/tpu: 4

--- a/microbenchmarks/ironwood/automation/autoscaling/tpu7x-2x2x4-collectives.yaml
+++ b/microbenchmarks/ironwood/automation/autoscaling/tpu7x-2x2x4-collectives.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-svc-${JOB_NAME}
+spec:
+  clusterIP: None
+  selector:
+    job-name: ${JOB_NAME}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue-tpu7x
+spec:
+  completionMode: Indexed
+  suspend: true
+  parallelism: 4
+  completions: 4
+  backoffLimit: 0
+  template:
+    spec:
+      subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
+      restartPolicy: Never
+      nodeSelector:
+        cloud.google.com/compute-class: tpuv7-2x2x4-class
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 2x2x4
+      containers:
+      - name: jax-tpu
+        image: python:3.12
+        securityContext:
+          privileged: false
+        env:
+        - name: JAX_PLATFORMS
+          value: "tpu,cpu"
+        - name: TPU_VMODULE
+          value: "singleton_tpu_system_manager=10,tpu_version_flag=10,device_util=10,device_scanner=10,mesh_builder=10,master=10"
+        - name: XLA_IR_DEBUG
+          value: "1"
+        - name: XLA_HLO_DEBUG
+          value: "1"
+        command:
+        - bash
+        - -c
+        - |
+          set -ex
+
+          git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+          cd accelerator-microbenchmarks
+          git checkout tpu7x-auto
+          pip install -r requirements.txt
+
+          GCS_BUCKET_DIR=${GCS_PATH}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_gather_tpu7x_2x2x4.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_reduce_tpu7x_2x2x4.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_to_all_tpu7x_2x2x4.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+        resources:
+          requests:
+            google.com/tpu: 4
+          limits:
+            google.com/tpu: 4

--- a/microbenchmarks/ironwood/automation/autoscaling/tpu7x-2x4x4-collectives.yaml
+++ b/microbenchmarks/ironwood/automation/autoscaling/tpu7x-2x4x4-collectives.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-svc-${JOB_NAME}
+spec:
+  clusterIP: None
+  selector:
+    job-name: ${JOB_NAME}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue-tpu7x
+spec:
+  completionMode: Indexed
+  suspend: true
+  parallelism: 8
+  completions: 8
+  backoffLimit: 0
+  template:
+    spec:
+      subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
+      restartPolicy: Never
+      nodeSelector:
+        cloud.google.com/compute-class: tpuv7-2x4x4-class
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 2x4x4
+      containers:
+      - name: jax-tpu
+        image: python:3.12
+        securityContext:
+          privileged: false
+        env:
+        - name: JAX_PLATFORMS
+          value: "tpu,cpu"
+        - name: TPU_VMODULE
+          value: "singleton_tpu_system_manager=10,tpu_version_flag=10,device_util=10,device_scanner=10,mesh_builder=10,master=10"
+        - name: XLA_IR_DEBUG
+          value: "1"
+        - name: XLA_HLO_DEBUG
+          value: "1"
+        command:
+        - bash
+        - -c
+        - |
+          set -ex
+
+          git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+          cd accelerator-microbenchmarks
+          git checkout tpu7x-auto
+          pip install -r requirements.txt
+
+          GCS_BUCKET_DIR=${GCS_PATH}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_gather_tpu7x_2x4x4.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_reduce_tpu7x_2x4x4.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_to_all_tpu7x_2x4x4.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+        resources:
+          requests:
+            google.com/tpu: 4
+          limits:
+            google.com/tpu: 4

--- a/microbenchmarks/ironwood/automation/autoscaling/tpu7x-4x4x4-collectives.yaml
+++ b/microbenchmarks/ironwood/automation/autoscaling/tpu7x-4x4x4-collectives.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-svc-${JOB_NAME}
+spec:
+  clusterIP: None
+  selector:
+    job-name: ${JOB_NAME}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue-tpu7x
+spec:
+  completionMode: Indexed
+  suspend: true
+  parallelism: 16
+  completions: 16
+  backoffLimit: 0
+  template:
+    spec:
+      subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
+      restartPolicy: Never
+      nodeSelector:
+        cloud.google.com/compute-class: tpuv7-4x4x4-class
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 4x4x4
+      containers:
+      - name: jax-tpu
+        image: python:3.12
+        securityContext:
+          privileged: false
+        env:
+        - name: JAX_PLATFORMS
+          value: "tpu,cpu"
+        - name: TPU_VMODULE
+          value: "singleton_tpu_system_manager=10,tpu_version_flag=10,device_util=10,device_scanner=10,mesh_builder=10,master=10"
+        - name: XLA_IR_DEBUG
+          value: "1"
+        - name: XLA_HLO_DEBUG
+          value: "1"
+        command:
+        - bash
+        - -c
+        - |
+          set -ex
+
+          git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+          cd accelerator-microbenchmarks
+          git checkout tpu7x-auto
+          pip install -r requirements.txt
+
+          GCS_BUCKET_DIR=${GCS_PATH}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_gather_tpu7x_4x4x4.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_reduce_tpu7x_4x4x4.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_to_all_tpu7x_4x4x4.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+        resources:
+          requests:
+            google.com/tpu: 4
+          limits:
+            google.com/tpu: 4

--- a/microbenchmarks/ironwood/automation/autoscaling/tpu7x-4x4x8-collectives.yaml
+++ b/microbenchmarks/ironwood/automation/autoscaling/tpu7x-4x4x8-collectives.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-svc-${JOB_NAME}
+spec:
+  clusterIP: None
+  selector:
+    job-name: ${JOB_NAME}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue-tpu7x
+spec:
+  completionMode: Indexed
+  suspend: true
+  parallelism: 32
+  completions: 32
+  backoffLimit: 0
+  template:
+    spec:
+      subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
+      restartPolicy: Never
+      nodeSelector:
+        cloud.google.com/compute-class: tpuv7-4x4x8-class
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 4x4x8
+      containers:
+      - name: jax-tpu
+        image: python:3.12
+        securityContext:
+          privileged: false
+        env:
+        - name: JAX_PLATFORMS
+          value: "tpu,cpu"
+        - name: TPU_VMODULE
+          value: "singleton_tpu_system_manager=10,tpu_version_flag=10,device_util=10,device_scanner=10,mesh_builder=10,master=10"
+        - name: XLA_IR_DEBUG
+          value: "1"
+        - name: XLA_HLO_DEBUG
+          value: "1"
+        command:
+        - bash
+        - -c
+        - |
+          set -ex
+
+          git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+          cd accelerator-microbenchmarks
+          git checkout tpu7x-auto
+          pip install -r requirements.txt
+
+          GCS_BUCKET_DIR=${GCS_PATH}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_gather_tpu7x_4x4x8.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_reduce_tpu7x_4x4x8.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_to_all_tpu7x_4x4x8.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+        resources:
+          requests:
+            google.com/tpu: 4
+          limits:
+            google.com/tpu: 4

--- a/microbenchmarks/ironwood/automation/check_gcs_permissions.sh
+++ b/microbenchmarks/ironwood/automation/check_gcs_permissions.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+
+# This script checks if the configured Service Account has write permissions to the specified GCS bucket.
+# If permissions are missing, it attempts to fix them by creating the SA and granting roles/storage.admin.
+#
+# Expected Environment Variables:
+#   GCS_BUCKET_ROOT_DIR: The GCS path (must start with gs://)
+#   SA_NAME: The Service Account name (default: gcs-writer)
+#   PROJECT_ID: The GCP Project ID (optional, will try to detect if not set)
+
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+SA_NAME="${SA_NAME:-gcs-writer}"
+PROJECT_ID="${PROJECT_ID:-$(gcloud config get-value project 2>/dev/null)}"
+
+if [[ -z "${GCS_BUCKET_ROOT_DIR}" || "${GCS_BUCKET_ROOT_DIR}" != "gs://"* ]]; then
+  echo "Error: GCS_BUCKET_ROOT_DIR must be set and start with gs://"
+  exit 1
+fi
+
+fix_gcs_permissions() {
+    # See more context in https://docs.cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to
+    echo "Attempting to fix GCS permissions..."
+    
+    if [[ -z "${PROJECT_ID}" ]]; then
+        echo "Error: PROJECT_ID is not set and could not be detected."
+        echo "Please export PROJECT_ID=<your-project-id> and rerun."
+        exit 1
+    fi
+    
+    local bucket_name=$(echo "${GCS_BUCKET_ROOT_DIR}" | sed 's|^gs://||' | cut -d/ -f1)
+    local ns_name="default"
+    
+    echo "Ensuring ServiceAccount ${SA_NAME} exists in namespace ${ns_name}..."
+    kubectl create serviceaccount "${SA_NAME}" --namespace "${ns_name}" --dry-run=client -o yaml | kubectl apply -f -
+    
+    local project_number=$(gcloud projects describe "${PROJECT_ID}" --format="value(projectNumber)")
+    
+    echo "Granting roles/storage.admin to ${SA_NAME} on gs://${bucket_name}..."
+    gcloud storage buckets add-iam-policy-binding "gs://${bucket_name}" \
+        --role=roles/storage.admin \
+        --member="principal://iam.googleapis.com/projects/${project_number}/locations/global/workloadIdentityPools/${PROJECT_ID}.svc.id.goog/subject/ns/${ns_name}/sa/${SA_NAME}"
+        
+    echo "Permission fix command executed."
+}
+
+check_gcs_permission() {
+    echo "Checking GCS write permissions..."
+    export GCS_CHECK_PATH="${GCS_BUCKET_ROOT_DIR}/permission-check-$(date +%s).txt"
+    export SA_NAME="${SA_NAME}"
+
+    # Check if ServiceAccount exists first to fail fast
+    if ! kubectl get serviceaccount "${SA_NAME}" &> /dev/null; then
+        echo "ServiceAccount '${SA_NAME}' not found."
+        return 1
+    fi
+    
+    # Launch check pod
+    # We capture the pod name from the output of kubectl create
+    local apply_output=$(envsubst '${SA_NAME} ${GCS_CHECK_PATH}' < "${SCRIPT_DIR}/gcs-write.yaml" | kubectl create -f -)
+    # output example: pod/gcs-writer-test-abcde created
+    local pod_name=$(echo "${apply_output}" | awk -F'/' '{print $2}' | awk '{print $1}')
+    
+    echo "Launched GCS check pod: ${pod_name}"
+    
+    # Wait for completion
+    local check_status="FAILED"
+    for i in {1..20}; do
+        sleep 5
+        if kubectl get pod "${pod_name}" -o jsonpath='{.status.phase}' 2>/dev/null | grep -q "Succeeded"; then
+            check_status="SUCCESS"
+            break
+        fi
+        if kubectl get pod "${pod_name}" -o jsonpath='{.status.phase}' 2>/dev/null | grep -q "Failed"; then
+            check_status="FAILED"
+            break
+        fi
+    done
+
+    # Check logs
+    if kubectl logs "${pod_name}" 2>/dev/null | grep -q "GCS test complete!"; then
+         echo "GCS permission check PASSED."
+         check_status="SUCCESS"
+    else
+         echo "GCS permission check FAILED."
+         check_status="FAILED"
+         echo "Logs from ${pod_name}:"
+         kubectl logs "${pod_name}" 2>/dev/null | tail -n 10
+    fi
+    
+    # Cleanup
+    kubectl delete pod "${pod_name}" --grace-period=0 --force &> /dev/null
+    
+    if [[ "${check_status}" != "SUCCESS" ]]; then
+        return 1
+    fi
+    return 0
+}
+
+# Main Logic
+echo "======================================================================"
+echo "Starting GCS Permission Check (SA: ${SA_NAME}, Bucket: ${GCS_BUCKET_ROOT_DIR})"
+echo "======================================================================"
+
+if ! check_gcs_permission; then
+    echo "GCS check failed. Attempting to fix..."
+    fix_gcs_permissions
+    
+    echo "Retrying GCS check..."
+    if ! check_gcs_permission; then
+        echo "GCS permissions check failed even after attempted fix."
+        echo "Please verify your Service Account '${SA_NAME}' has proper permissions on ${GCS_BUCKET_ROOT_DIR}"
+        exit 1
+    fi
+fi
+
+echo "GCS Check Verified Successfully."

--- a/microbenchmarks/ironwood/automation/check_node_pool_setup.sh
+++ b/microbenchmarks/ironwood/automation/check_node_pool_setup.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+required_chip="tpu7x"
+if [[ $# -gt 0 ]]; then
+  required_topologies=("$@")
+else
+  required_topologies=("2x2x1" "2x2x2" "2x2x4" "2x4x4" "4x4x4")
+fi
+
+echo "Checking for required GKE TPU configurations..."
+echo "Required TPU Type: ${required_chip}"
+echo "-----------------------------------------------------------------"
+
+all_found=true
+missing_topologies=()
+
+
+for topology in "${required_topologies[@]}"; do
+  echo -n "Checking for TPU topology '${topology}' with type '${required_chip}': "
+
+  matching_nodes=$(kubectl get nodes -l cloud.google.com/gke-tpu-topology=${topology},cloud.google.com/gke-tpu-accelerator=${required_chip} -o custom-columns=NAME:.metadata.name --no-headers 2>/dev/null)
+
+  if [[ -n "${matching_nodes}" ]]; then
+    echo "FOUND"
+  else
+    echo "MISSING"
+    missing_topologies+=("${topology}")
+    all_found=false
+  fi
+done
+
+echo "-----------------------------------------------------------------"
+
+if [[ "${all_found}" = true ]]; then
+  echo "SUCCESS: All required TPU configurations (topology + type) are present in the cluster."
+  exit 0
+else
+  echo "FAILURE: One or more required TPU configurations are missing."
+  echo "Missing topologies: ${missing_topologies[@]}"
+  exit 1
+fi

--- a/microbenchmarks/ironwood/automation/gcs-write.yaml
+++ b/microbenchmarks/ironwood/automation/gcs-write.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: gcs-writer-test-
+  namespace: default
+spec:
+  serviceAccountName: ${SA_NAME}
+  containers:
+  - name: gcs-test-container
+    image: google/cloud-sdk:slim
+    command:
+    - bash
+    - -c
+    - |
+      set -ex
+      TIMESTAMP=$(date +%s)
+      LOCAL_FILE="/tmp/test-file-${TIMESTAMP}.txt"
+      
+      # GCS_CHECK_PATH is substituted by envsubst
+      echo "Using GCS Path: ${GCS_CHECK_PATH}"
+
+      echo "Testing GCS write from pod at $(date)" > "${LOCAL_FILE}"
+
+      echo "--- Configuration ---"
+      gcloud auth list
+      gcloud config list
+      # Try to get service account email, but don't fail if metadata server is slow/unreachable (though it should be reachable)
+      curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/email" || echo "Could not fetch SA email"
+      echo
+
+      echo "--- Writing to GCS ---"
+      gsutil cp "${LOCAL_FILE}" "${GCS_CHECK_PATH}"
+
+      echo "--- Verifying from GCS ---"
+      gsutil cat "${GCS_CHECK_PATH}"
+
+      echo "--- Cleaning up GCS object ---"
+      gsutil rm "${GCS_CHECK_PATH}"
+
+      echo "GCS test complete!"
+  restartPolicy: Never

--- a/microbenchmarks/ironwood/automation/job-queue.yaml
+++ b/microbenchmarks/ironwood/automation/job-queue.yaml
@@ -1,0 +1,41 @@
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  name: "flavor-${TOPOLOGY}"
+spec:
+  nodeLabels:
+    cloud.google.com/gke-tpu-accelerator: tpu7x
+    cloud.google.com/gke-tpu-topology: ${TOPOLOGY}
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: cluster-queue-${TOPOLOGY}
+spec:
+  flavorFungibility:
+    whenCanBorrow: MayStopSearch
+    whenCanPreempt: TryNextFlavor
+  namespaceSelector: {}
+  preemption:
+    borrowWithinCohort:
+      policy: Never
+    reclaimWithinCohort: Never
+    withinClusterQueue: LowerPriority
+  queueingStrategy: BestEffortFIFO
+  resourceGroups:
+  - coveredResources:
+    - google.com/tpu
+    flavors:
+    - name: flavor-${TOPOLOGY}
+      resources:
+      - name: google.com/tpu
+        nominalQuota: ${TPUS}
+  stopPolicy: None
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata:
+  namespace: default
+  name: "user-queue-${TOPOLOGY}"
+spec:
+  clusterQueue: "cluster-queue-${TOPOLOGY}"

--- a/microbenchmarks/ironwood/automation/tpu7x-2x2x1-attention.yaml
+++ b/microbenchmarks/ironwood/automation/tpu7x-2x2x1-attention.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-svc-${JOB_NAME}
+spec:
+  clusterIP: None
+  selector:
+    job-name: ${JOB_NAME}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue-2x2x1
+spec:
+  completionMode: Indexed
+  suspend: true
+  parallelism: 1
+  completions: 1
+  backoffLimit: 0
+  template:
+    spec:
+      subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
+      restartPolicy: Never
+      nodeSelector:
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 2x2x1
+      containers:
+      - name: jax-tpu
+        image: python:3.12
+        securityContext:
+          privileged: false
+        env:
+        - name: JAX_PLATFORMS
+          value: "tpu,cpu"
+        - name: TPU_VMODULE
+          value: "singleton_tpu_system_manager=10,tpu_version_flag=10,device_util=10,device_scanner=10,mesh_builder=10,master=10"
+        - name: XLA_IR_DEBUG
+          value: "1"
+        - name: XLA_HLO_DEBUG
+          value: "1"
+        command:
+        - bash
+        - -c
+        - |
+          set -ex
+
+          git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+          cd accelerator-microbenchmarks
+          git checkout tpu7x-auto
+          pip install -r requirements.txt
+
+          GCS_BUCKET_DIR=${GCS_PATH}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/attention/attention.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+        resources:
+          requests:
+            google.com/tpu: 4
+          limits:
+            google.com/tpu: 4

--- a/microbenchmarks/ironwood/automation/tpu7x-2x2x1-bmm.yaml
+++ b/microbenchmarks/ironwood/automation/tpu7x-2x2x1-bmm.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-svc-${JOB_NAME}
+spec:
+  clusterIP: None
+  selector:
+    job-name: ${JOB_NAME}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue-2x2x1
+spec:
+  completionMode: Indexed
+  suspend: true
+  parallelism: 1
+  completions: 1
+  backoffLimit: 0
+  template:
+    spec:
+      subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
+      restartPolicy: Never
+      nodeSelector:
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 2x2x1
+      containers:
+      - name: jax-tpu
+        image: python:3.12
+        securityContext:
+          privileged: false
+        env:
+        - name: JAX_PLATFORMS
+          value: "tpu,cpu"
+        - name: TPU_VMODULE
+          value: "singleton_tpu_system_manager=10,tpu_version_flag=10,device_util=10,device_scanner=10,mesh_builder=10,master=10"
+        - name: XLA_IR_DEBUG
+          value: "1"
+        - name: XLA_HLO_DEBUG
+          value: "1"
+        command:
+        - bash
+        - -c
+        - |
+          set -ex
+
+          git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+          cd accelerator-microbenchmarks
+          git checkout tpu7x-auto
+          pip install -r requirements.txt
+
+          GCS_BUCKET_DIR=${GCS_PATH}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/bmm/single_device_bmm.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+        resources:
+          requests:
+            google.com/tpu: 4
+          limits:
+            google.com/tpu: 4

--- a/microbenchmarks/ironwood/automation/tpu7x-2x2x1-collectives.yaml
+++ b/microbenchmarks/ironwood/automation/tpu7x-2x2x1-collectives.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-svc-${JOB_NAME}
+spec:
+  clusterIP: None
+  selector:
+    job-name: ${JOB_NAME}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue-2x2x1
+spec:
+  completionMode: Indexed
+  suspend: true
+  parallelism: 1
+  completions: 1
+  backoffLimit: 0
+  template:
+    spec:
+      subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
+      restartPolicy: Never
+      nodeSelector:
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 2x2x1
+      containers:
+      - name: jax-tpu
+        image: python:3.12
+        securityContext:
+          privileged: false
+        env:
+        - name: JAX_PLATFORMS
+          value: "tpu,cpu"
+        - name: TPU_VMODULE
+          value: "singleton_tpu_system_manager=10,tpu_version_flag=10,device_util=10,device_scanner=10,mesh_builder=10,master=10"
+        - name: XLA_IR_DEBUG
+          value: "1"
+        - name: XLA_HLO_DEBUG
+          value: "1"
+        command:
+        - bash
+        - -c
+        - |
+          set -ex
+
+          git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+          cd accelerator-microbenchmarks
+          git checkout tpu7x-auto
+          pip install -r requirements.txt
+
+          GCS_BUCKET_DIR=${GCS_PATH}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_gather_tpu7x_2x2x1.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_reduce_tpu7x_2x2x1.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_to_all_tpu7x_2x2x1.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+        resources:
+          requests:
+            google.com/tpu: 4
+          limits:
+            google.com/tpu: 4

--- a/microbenchmarks/ironwood/automation/tpu7x-2x2x1-gemm.yaml
+++ b/microbenchmarks/ironwood/automation/tpu7x-2x2x1-gemm.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-svc-${JOB_NAME}
+spec:
+  clusterIP: None
+  selector:
+    job-name: ${JOB_NAME}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue-2x2x1
+spec:
+  completionMode: Indexed
+  suspend: true
+  parallelism: 1
+  completions: 1
+  backoffLimit: 0
+  template:
+    spec:
+      subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
+      restartPolicy: Never
+      nodeSelector:
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 2x2x1
+      containers:
+      - name: jax-tpu
+        image: python:3.12
+        securityContext:
+          privileged: false
+        env:
+        - name: JAX_PLATFORMS
+          value: "tpu,cpu"
+        - name: TPU_VMODULE
+          value: "singleton_tpu_system_manager=10,tpu_version_flag=10,device_util=10,device_scanner=10,mesh_builder=10,master=10"
+        - name: XLA_IR_DEBUG
+          value: "1"
+        - name: XLA_HLO_DEBUG
+          value: "1"
+        command:
+        - bash
+        - -c
+        - |
+          set -ex
+
+          git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+          cd accelerator-microbenchmarks
+          git checkout tpu7x-auto
+          pip install -r requirements.txt
+
+          GCS_BUCKET_DIR=${GCS_PATH}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/gemm/gemm_multiple_run_more.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+        resources:
+          requests:
+            google.com/tpu: 4
+          limits:
+            google.com/tpu: 4

--- a/microbenchmarks/ironwood/automation/tpu7x-2x2x1-gemm_all_reduce.yaml
+++ b/microbenchmarks/ironwood/automation/tpu7x-2x2x1-gemm_all_reduce.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-svc-${JOB_NAME}
+spec:
+  clusterIP: None
+  selector:
+    job-name: ${JOB_NAME}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue-2x2x1
+spec:
+  completionMode: Indexed
+  suspend: true
+  parallelism: 1
+  completions: 1
+  backoffLimit: 0
+  template:
+    spec:
+      subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
+      restartPolicy: Never
+      nodeSelector:
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 2x2x1
+      containers:
+      - name: jax-tpu
+        image: python:3.12
+        securityContext:
+          privileged: false
+        env:
+        - name: JAX_PLATFORMS
+          value: "tpu,cpu"
+        - name: TPU_VMODULE
+          value: "singleton_tpu_system_manager=10,tpu_version_flag=10,device_util=10,device_scanner=10,mesh_builder=10,master=10"
+        - name: XLA_IR_DEBUG
+          value: "1"
+        - name: XLA_HLO_DEBUG
+          value: "1"
+        command:
+        - bash
+        - -c
+        - |
+          set -ex
+
+          git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+          cd accelerator-microbenchmarks
+          git checkout tpu7x-auto
+          pip install -r requirements.txt
+
+          GCS_BUCKET_DIR=${GCS_PATH}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/gemm_all_reduce/gemm_all_reduce.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+        resources:
+          requests:
+            google.com/tpu: 4
+          limits:
+            google.com/tpu: 4

--- a/microbenchmarks/ironwood/automation/tpu7x-2x2x1-hbm.yaml
+++ b/microbenchmarks/ironwood/automation/tpu7x-2x2x1-hbm.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-svc-${JOB_NAME}
+spec:
+  clusterIP: None
+  selector:
+    job-name: ${JOB_NAME}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue-2x2x1
+spec:
+  completionMode: Indexed
+  suspend: true
+  parallelism: 1
+  completions: 1
+  backoffLimit: 0
+  template:
+    spec:
+      subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
+      restartPolicy: Never
+      nodeSelector:
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 2x2x1
+      containers:
+      - name: jax-tpu
+        image: python:3.12
+        securityContext:
+          privileged: false
+        env:
+        - name: JAX_PLATFORMS
+          value: "tpu,cpu"
+        - name: TPU_VMODULE
+          value: "singleton_tpu_system_manager=10,tpu_version_flag=10,device_util=10,device_scanner=10,mesh_builder=10,master=10"
+        - name: XLA_IR_DEBUG
+          value: "1"
+        - name: XLA_HLO_DEBUG
+          value: "1"
+        command:
+        - bash
+        - -c
+        - |
+          set -ex
+
+          git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+          cd accelerator-microbenchmarks
+          git checkout tpu7x-auto
+          pip install -r requirements.txt
+
+          GCS_BUCKET_DIR=${GCS_PATH}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/hbm/hbm.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+        resources:
+          requests:
+            google.com/tpu: 4
+          limits:
+            google.com/tpu: 4

--- a/microbenchmarks/ironwood/automation/tpu7x-2x2x1-host_device.yaml
+++ b/microbenchmarks/ironwood/automation/tpu7x-2x2x1-host_device.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-svc-${JOB_NAME}
+spec:
+  clusterIP: None
+  selector:
+    job-name: ${JOB_NAME}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue-2x2x1
+spec:
+  completionMode: Indexed
+  suspend: true
+  parallelism: 1
+  completions: 1
+  backoffLimit: 0
+  template:
+    spec:
+      subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
+      restartPolicy: Never
+      nodeSelector:
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 2x2x1
+      containers:
+      - name: jax-tpu
+        image: python:3.12
+        securityContext:
+          privileged: false
+        env:
+        - name: JAX_PLATFORMS
+          value: "tpu,cpu"
+        - name: TPU_VMODULE
+          value: "singleton_tpu_system_manager=10,tpu_version_flag=10,device_util=10,device_scanner=10,mesh_builder=10,master=10"
+        - name: XLA_IR_DEBUG
+          value: "1"
+        - name: XLA_HLO_DEBUG
+          value: "1"
+        command:
+        - bash
+        - -c
+        - |
+          set -ex
+
+          git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+          cd accelerator-microbenchmarks
+          git checkout tpu7x-auto
+          pip install -r requirements.txt
+
+          GCS_BUCKET_DIR=${GCS_PATH}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/host_device/host_device.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+        resources:
+          requests:
+            google.com/tpu: 4
+          limits:
+            google.com/tpu: 4

--- a/microbenchmarks/ironwood/automation/tpu7x-2x2x2-collectives.yaml
+++ b/microbenchmarks/ironwood/automation/tpu7x-2x2x2-collectives.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-svc-${JOB_NAME}
+spec:
+  clusterIP: None
+  selector:
+    job-name: ${JOB_NAME}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue-2x2x2
+spec:
+  completionMode: Indexed
+  suspend: true
+  parallelism: 2
+  completions: 2
+  backoffLimit: 0
+  template:
+    spec:
+      subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
+      restartPolicy: Never
+      nodeSelector:
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 2x2x2
+      containers:
+      - name: jax-tpu
+        image: python:3.12
+        securityContext:
+          privileged: false
+        env:
+        - name: JAX_PLATFORMS
+          value: "tpu,cpu"
+        - name: TPU_VMODULE
+          value: "singleton_tpu_system_manager=10,tpu_version_flag=10,device_util=10,device_scanner=10,mesh_builder=10,master=10"
+        - name: XLA_IR_DEBUG
+          value: "1"
+        - name: XLA_HLO_DEBUG
+          value: "1"
+        command:
+        - bash
+        - -c
+        - |
+          set -ex
+
+          git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+          cd accelerator-microbenchmarks
+          git checkout tpu7x-auto
+          pip install -r requirements.txt
+
+          GCS_BUCKET_DIR=${GCS_PATH}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_gather_tpu7x_2x2x2.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_reduce_tpu7x_2x2x2.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_to_all_tpu7x_2x2x2.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+        resources:
+          requests:
+            google.com/tpu: 4
+          limits:
+            google.com/tpu: 4

--- a/microbenchmarks/ironwood/automation/tpu7x-2x2x4-collectives.yaml
+++ b/microbenchmarks/ironwood/automation/tpu7x-2x2x4-collectives.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-svc-${JOB_NAME}
+spec:
+  clusterIP: None
+  selector:
+    job-name: ${JOB_NAME}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue-2x2x4
+spec:
+  completionMode: Indexed
+  suspend: true
+  parallelism: 4
+  completions: 4
+  backoffLimit: 0
+  template:
+    spec:
+      subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
+      restartPolicy: Never
+      nodeSelector:
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 2x2x4
+      containers:
+      - name: jax-tpu
+        image: python:3.12
+        securityContext:
+          privileged: false
+        env:
+        - name: JAX_PLATFORMS
+          value: "tpu,cpu"
+        - name: TPU_VMODULE
+          value: "singleton_tpu_system_manager=10,tpu_version_flag=10,device_util=10,device_scanner=10,mesh_builder=10,master=10"
+        - name: XLA_IR_DEBUG
+          value: "1"
+        - name: XLA_HLO_DEBUG
+          value: "1"
+        command:
+        - bash
+        - -c
+        - |
+          set -ex
+
+          git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+          cd accelerator-microbenchmarks
+          git checkout tpu7x-auto
+          pip install -r requirements.txt
+
+          GCS_BUCKET_DIR=${GCS_PATH}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_gather_tpu7x_2x2x4.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_reduce_tpu7x_2x2x4.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_to_all_tpu7x_2x2x4.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+        resources:
+          requests:
+            google.com/tpu: 4
+          limits:
+            google.com/tpu: 4

--- a/microbenchmarks/ironwood/automation/tpu7x-2x4x4-collectives.yaml
+++ b/microbenchmarks/ironwood/automation/tpu7x-2x4x4-collectives.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-svc-${JOB_NAME}
+spec:
+  clusterIP: None
+  selector:
+    job-name: ${JOB_NAME}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue-2x4x4
+spec:
+  completionMode: Indexed
+  suspend: true
+  parallelism: 8
+  completions: 8
+  backoffLimit: 0
+  template:
+    spec:
+      subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
+      restartPolicy: Never
+      nodeSelector:
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 2x4x4
+      containers:
+      - name: jax-tpu
+        image: python:3.12
+        securityContext:
+          privileged: false
+        env:
+        - name: JAX_PLATFORMS
+          value: "tpu,cpu"
+        - name: TPU_VMODULE
+          value: "singleton_tpu_system_manager=10,tpu_version_flag=10,device_util=10,device_scanner=10,mesh_builder=10,master=10"
+        - name: XLA_IR_DEBUG
+          value: "1"
+        - name: XLA_HLO_DEBUG
+          value: "1"
+        command:
+        - bash
+        - -c
+        - |
+          set -ex
+
+          git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+          cd accelerator-microbenchmarks
+          git checkout tpu7x-auto
+          pip install -r requirements.txt
+
+          GCS_BUCKET_DIR=${GCS_PATH}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_gather_tpu7x_2x4x4.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_reduce_tpu7x_2x4x4.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_to_all_tpu7x_2x4x4.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+        resources:
+          requests:
+            google.com/tpu: 4
+          limits:
+            google.com/tpu: 4

--- a/microbenchmarks/ironwood/automation/tpu7x-4x4x4-collectives.yaml
+++ b/microbenchmarks/ironwood/automation/tpu7x-4x4x4-collectives.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-svc-${JOB_NAME}
+spec:
+  clusterIP: None
+  selector:
+    job-name: ${JOB_NAME}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue-4x4x4
+spec:
+  completionMode: Indexed
+  suspend: true
+  parallelism: 16
+  completions: 16
+  backoffLimit: 0
+  template:
+    spec:
+      subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
+      restartPolicy: Never
+      nodeSelector:
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 4x4x4
+      containers:
+      - name: jax-tpu
+        image: python:3.12
+        securityContext:
+          privileged: false
+        env:
+        - name: JAX_PLATFORMS
+          value: "tpu,cpu"
+        - name: TPU_VMODULE
+          value: "singleton_tpu_system_manager=10,tpu_version_flag=10,device_util=10,device_scanner=10,mesh_builder=10,master=10"
+        - name: XLA_IR_DEBUG
+          value: "1"
+        - name: XLA_HLO_DEBUG
+          value: "1"
+        command:
+        - bash
+        - -c
+        - |
+          set -ex
+
+          git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+          cd accelerator-microbenchmarks
+          git checkout tpu7x-auto
+          pip install -r requirements.txt
+
+          GCS_BUCKET_DIR=${GCS_PATH}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_gather_tpu7x_4x4x4.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_reduce_tpu7x_4x4x4.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_to_all_tpu7x_4x4x4.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+        resources:
+          requests:
+            google.com/tpu: 4
+          limits:
+            google.com/tpu: 4

--- a/microbenchmarks/ironwood/automation/tpu7x-4x4x4-gemm_all_reduce.yaml
+++ b/microbenchmarks/ironwood/automation/tpu7x-4x4x4-gemm_all_reduce.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-svc-${JOB_NAME}
+spec:
+  clusterIP: None
+  selector:
+    job-name: ${JOB_NAME}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue-4x4x4
+spec:
+  completionMode: Indexed
+  suspend: true
+  parallelism: 16
+  completions: 16
+  backoffLimit: 0
+  template:
+    spec:
+      subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
+      restartPolicy: Never
+      nodeSelector:
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 4x4x4
+      containers:
+      - name: jax-tpu
+        image: python:3.12
+        securityContext:
+          privileged: false
+        env:
+        - name: JAX_PLATFORMS
+          value: "tpu,cpu"
+        - name: TPU_VMODULE
+          value: "singleton_tpu_system_manager=10,tpu_version_flag=10,device_util=10,device_scanner=10,mesh_builder=10,master=10"
+        - name: XLA_IR_DEBUG
+          value: "1"
+        - name: XLA_HLO_DEBUG
+          value: "1"
+        command:
+        - bash
+        - -c
+        - |
+          set -ex
+
+          git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+          cd accelerator-microbenchmarks
+          git checkout tpu7x-auto
+          pip install -r requirements.txt
+
+          GCS_BUCKET_DIR=${GCS_PATH}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/gemm_all_reduce/gemm_all_reduce.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+        resources:
+          requests:
+            google.com/tpu: 4
+          limits:
+            google.com/tpu: 4

--- a/microbenchmarks/ironwood/automation/tpu7x-4x4x8-collectives.yaml
+++ b/microbenchmarks/ironwood/automation/tpu7x-4x4x8-collectives.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-svc-${JOB_NAME}
+spec:
+  clusterIP: None
+  selector:
+    job-name: ${JOB_NAME}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue-4x4x8
+spec:
+  completionMode: Indexed
+  suspend: true
+  parallelism: 32
+  completions: 32
+  backoffLimit: 0
+  template:
+    spec:
+      subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
+      restartPolicy: Never
+      nodeSelector:
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 4x4x8
+      containers:
+      - name: jax-tpu
+        image: python:3.12
+        securityContext:
+          privileged: false
+        env:
+        - name: JAX_PLATFORMS
+          value: "tpu,cpu"
+        - name: TPU_VMODULE
+          value: "singleton_tpu_system_manager=10,tpu_version_flag=10,device_util=10,device_scanner=10,mesh_builder=10,master=10"
+        - name: XLA_IR_DEBUG
+          value: "1"
+        - name: XLA_HLO_DEBUG
+          value: "1"
+        command:
+        - bash
+        - -c
+        - |
+          set -ex
+
+          git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+          cd accelerator-microbenchmarks
+          git checkout tpu7x-auto
+          pip install -r requirements.txt
+
+          GCS_BUCKET_DIR=${GCS_PATH}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_gather_tpu7x_4x4x8.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_reduce_tpu7x_4x4x8.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_to_all_tpu7x_4x4x8.yaml" --gcs-bucket-csv-dir=${GCS_BUCKET_DIR}
+        resources:
+          requests:
+            google.com/tpu: 4
+          limits:
+            google.com/tpu: 4

--- a/microbenchmarks/ironwood/collectives/all_gather.md
+++ b/microbenchmarks/ironwood/collectives/all_gather.md
@@ -1,0 +1,57 @@
+# All Gather Microbenchmark
+
+This guide demonstrates how to performance collective benchmark for the `2x2x1` and `2x2x2` topologies.
+
+## Setup
+Please follow the prerequisites setup [here](../../Ironwood_Microbenchmarks_readme.md#prerequisites).
+
+### Create Node Pool
+
+Refer to the instructions [here](../../Ironwood_Microbenchmarks_readme.md#setup) to create `2x2x1` and `2x2x2` node pools, making sure to adjust the accelerator-topology from `4x4x4` to `2x2x2`.
+
+## Run Benchmarks
+
+Deploy the all_gather microbenchmarks for different TPU topologies.
+```
+kubectl apply -f tpu7x-2x2x1-ici-all-gather-microbenchmark.yaml
+kubectl apply -f tpu7x-2x2x2-ici-all-gather-microbenchmark.yaml
+```
+
+### Monitor Results
+
+Use the following commands to retrieve the benchmark logs.
+```bash
+kubectl logs pod/tpu7x-2x2x1-ici-all-gather-microbenchmark
+kubectl logs job.batch/tpu7x-2x2x2-ici-all-gather-microbenchmark
+```
+
+Once the benchmark completes, you should see logs similar to the example below:
+```bash
+metadata:  {'iteration': 16384, 'op_type': 'AG' ... }
+metrics:  {... 'achieved_bw (GB/s)_max': np.float64(159.35667369827922) ...}
+Writing metrics to JSONL file: ../microbenchmarks/all_gather/metrics_report.jsonl
+Metrics written to CSV at ../microbenchmarks/all_gather/t_all_gather_[A-Z0-9]+.tsv.
+```
+
+To retrieve the complete results, use the `kubectl cp` command to copy the TSV report file, typically named `t_all_gather_[A-Z0-9]+.tsv`, from the `/microbenchmarks` directory within the pod.
+
+### Cleanup
+
+```bash
+kubectl delete -f tpu7x-2x2x1-ici-all-gather-microbenchmark.yaml
+kubectl delete -f tpu7x-2x2x2-ici-all-gather-microbenchmark.yaml
+```
+
+## Expected Results
+| Topology | Number of Elements | Achieved Bandwidth (GB/s) | Transferred Data (GB) | Input Shape      | Output  Shape    |
+| -------- | ------------------ | ------------------------- | --------------------- | ---------------- | ---------------- |
+| 2x2x1    | 65536              | 71.7703034                | 0.001572864           | f32[64,8,128]    | f32[256,8,128]   |
+| 2x2x1    | 262144             | 129.1869148               | 0.006291456           | f32[256,8,128]   | f32[1024,8,128]  |
+| 2x2x1    | 1048576            | 161.9040742               | 0.025165824           | f32[1024,8,128]  | f32[4096,8,128]  |
+| 2x2x1    | 4194304            | 174.765465                | 0.100663296           | f32[4096,8,128]  | f32[16384,8,128] |
+| 2x2x1    | 16777216           | 178.7714158               | 0.402653184           | f32[16384,8,128] | f32[65536,8,128] |
+| 2x2x2    | 65536              | 69.53210305               | 0.001572864           | f32[64,8,128]    | f32[256,8,128]   |
+| 2x2x2    | 262144             | 127.3945462               | 0.006291456           | f32[256,8,128]   | f32[1024,8,128]  |
+| 2x2x2    | 1048576            | 162.0864029               | 0.025165824           | f32[1024,8,128]  | f32[4096,8,128]  |
+| 2x2x2    | 4194304            | 174.6652133               | 0.100663296           | f32[4096,8,128]  | f32[16384,8,128] |
+| 2x2x2    | 16777216           | 178.7592252               | 0.402653184           | f32[16384,8,128] | f32[65536,8,128] |

--- a/microbenchmarks/ironwood/collectives/tpu7x-2x2x1-ici-all-gather-microbenchmark.yaml
+++ b/microbenchmarks/ironwood/collectives/tpu7x-2x2x1-ici-all-gather-microbenchmark.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tpu7x-2x2x1-ici-all-gather-microbenchmark
+spec:
+  restartPolicy: Never
+  nodeSelector:
+    cloud.google.com/gke-tpu-accelerator: tpu7x
+    cloud.google.com/gke-tpu-topology: 2x2x1
+  containers:
+  - name: tpu-job
+    image: python:3.12
+    ports:
+    - containerPort: 8431
+    securityContext:
+      privileged: false
+    command:
+    - bash
+    - -c
+    - |
+      set -ex
+      git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+      cd accelerator-microbenchmarks
+      pip install -r requirements.txt
+      python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_gather_tpu7x_2x2x1.yaml"
+    resources:
+      requests:
+        google.com/tpu: 4
+      limits:
+        google.com/tpu: 4

--- a/microbenchmarks/ironwood/collectives/tpu7x-2x2x2-ici-all-gather-microbenchmark.yaml
+++ b/microbenchmarks/ironwood/collectives/tpu7x-2x2x2-ici-all-gather-microbenchmark.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-svc
+spec:
+  clusterIP: None
+  selector:
+    job-name: tpu7x-2x2x2-ici-all-gather-microbenchmark
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: tpu7x-2x2x2-ici-all-gather-microbenchmark
+spec:
+  completionMode: Indexed
+  parallelism: 2
+  completions: 2
+  backoffLimit: 0
+  template:
+    spec:
+      subdomain: headless-svc
+      restartPolicy: Never
+      nodeSelector:
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 2x2x2
+      containers:
+      - name: jax-tpu
+        image: python:3.12
+        securityContext:
+          privileged: false
+        env:
+        - name: JAX_PLATFORMS
+          value: "tpu,cpu"
+        - name: TPU_VMODULE
+          value: "singleton_tpu_system_manager=10,tpu_version_flag=10,device_util=10,device_scanner=10,mesh_builder=10,master=10"
+        - name: XLA_IR_DEBUG
+          value: "1"
+        - name: XLA_HLO_DEBUG
+          value: "1"
+        command:
+        - bash
+        - -c
+        - |
+          set -ex
+          git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+          cd accelerator-microbenchmarks
+          pip install -r requirements.txt
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_gather_tpu7x_2x2x2.yaml"
+        resources:
+          requests:
+            google.com/tpu: 4
+          limits:
+            google.com/tpu: 4

--- a/microbenchmarks/ironwood/collectives/tpu7x-4x4x4-ici-all-gather-microbenchmark.yaml
+++ b/microbenchmarks/ironwood/collectives/tpu7x-4x4x4-ici-all-gather-microbenchmark.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-svc
+spec:
+  clusterIP: None
+  selector:
+    job-name: tpu7x-4x4x4-ici-all-gather-microbenchmark
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: tpu7x-4x4x4-ici-all-gather-microbenchmark
+spec:
+  completionMode: Indexed
+  parallelism: 16
+  completions: 16
+  backoffLimit: 0
+  template:
+    spec:
+      subdomain: headless-svc
+      restartPolicy: Never
+      nodeSelector:
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 4x4x4
+      containers:
+      - name: jax-tpu
+        image: python:3.12
+        securityContext:
+          privileged: false
+        env:
+        - name: JAX_PLATFORMS
+          value: "tpu,cpu"
+        - name: TPU_VMODULE
+          value: "singleton_tpu_system_manager=10,tpu_version_flag=10,device_util=10,device_scanner=10,mesh_builder=10,master=10"
+        - name: XLA_IR_DEBUG
+          value: "1"
+        - name: XLA_HLO_DEBUG
+          value: "1"
+        command:
+        - bash
+        - -c
+        - |
+          set -ex
+          git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+          cd accelerator-microbenchmarks
+          pip install -r requirements.txt
+          python Ironwood/src/run_benchmark.py --config="Ironwood/configs/collectives/all_gather_tpu7x_4x4x4.yaml"
+        resources:
+          requests:
+            google.com/tpu: 4
+          limits:
+            google.com/tpu: 4

--- a/microbenchmarks/ironwood/hbm/hbm.md
+++ b/microbenchmarks/ironwood/hbm/hbm.md
@@ -1,0 +1,53 @@
+# HBM Microbnechmarks on tpu7x-2x2x1
+
+This guide provides instructions for running High Bandwidth Memory (HBM) microbenchmarks on tpu7x-2x2x1 Google Kubernetes Engine (GKE) clusters. It covers creating a node pool, running the benchmarks, and viewing the expected output.
+
+## Create Node Pools
+
+Follow [Setup section](../../Ironwood_Microbenchmarks_readme.md#setup) to create a GKE cluster with one 2x2x1 nodepool.
+
+## Run HBM Microbenchmarks
+
+To run the HBM microbenchmarks, apply the following Kubernetes configuration:
+```bash
+kubectl apply -f tpu7x-2x2x1-hbm-microbenchmark.yaml
+```
+
+To extract the log of HBM microbenchmark, use `kubectl log`:
+```bash
+kubectl log tpu7x-2x2x1-hbm-microbenchmark
+```
+
+Once the benchmark completes, you should see logs similar to the example below:
+
+```bash
+Tensor size: 8192.0 MB, time taken (median): 5.3523 ms, bandwidth (median): 3209.812 GB/s
+
+Writing metrics to JSONL file: ../microbenchmarks/hbm/metrics_report.jsonl
+Metrics written to CSV at ../microbenchmarks/hbm/t_single_device_hbm_copy_[A-Z0-9]+.tsv.
+```
+
+To retrieve the complete results, including the trace and TSV output files, you must keep the pod running after the benchmark completes. To do this, add a `sleep` command to the `tpu7x-2x2x1-hbm-microbenchmark.yaml` file. You can then use `kubectl cp` to copy the output from the pod.
+
+```bash
+kubectl cp tpu7x-2x2x1-hbm-microbenchmark:/microbenchmarks/hbm hbm
+```
+
+## Expected bandwidth for different matrix size
+
+
+| Matrix Size (Bytes) | Bandwidth (GB/s/core) | Bandwidth (GB/s/chip) |
+|---------------------|-----------------------|-----------------------|
+|             2097152 |           1379.335021 |           2758.670041 |
+|             4194304 |           2249.746091 |           4499.492181 |
+|             8388608 |           2246.129937 |           4492.259875 |
+|            16777216 |           2757.308985 |            5514.61797 |
+|            33554432 |            3009.83593 |            6019.67186 |
+|            67108864 |           3097.217778 |           6194.435556 |
+|           134217728 |            3176.50274 |           6353.005481 |
+|           268435456 |           3167.144485 |           6334.288969 |
+|           536870912 |           3199.020504 |           6398.041009 |
+|          1073741824 |           3198.414211 |           6396.828421 |
+|          2147483648 |           3203.486119 |           6406.972238 |
+|          4294967296 |           3197.879607 |           6395.759214 |
+|          8589934592 |           3210.480912 |           6420.961823 |

--- a/microbenchmarks/ironwood/hbm/tpu7x-2x2x1-hbm-microbenchmark.yaml
+++ b/microbenchmarks/ironwood/hbm/tpu7x-2x2x1-hbm-microbenchmark.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tpu7x-2x2x1-hbm-microbenchmark
+spec:
+  restartPolicy: Never
+  nodeSelector:
+    cloud.google.com/gke-tpu-accelerator: tpu7x
+    cloud.google.com/gke-tpu-topology: 2x2x1
+  containers:
+  - name: tpu-job
+    image: python:3.12
+    ports:
+    - containerPort: 8431
+    securityContext:
+      privileged: false
+    command:
+    - bash
+    - -c
+    - |
+      set -ex
+
+      git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+      cd accelerator-microbenchmarks
+      pip install -r requirements.txt
+
+      python Ironwood/src/run_benchmark.py --config="Ironwood/configs/hbm/hbm.yaml"
+
+    resources:
+      requests:
+        google.com/tpu: 4
+      limits:
+        google.com/tpu: 4

--- a/microbenchmarks/ironwood/host_device/host_device.md
+++ b/microbenchmarks/ironwood/host_device/host_device.md
@@ -1,0 +1,30 @@
+# Host Device Microbenchmarks on tpu7x-2x2x1
+
+This guide provides instructions for running Host Device (Host-to-Device and Device-to-Host) microbenchmarks on tpu7x-2x2x1 Google Kubernetes Engine (GKE) clusters. It covers creating a node pool, running the benchmarks, and viewing the output.
+
+> [!WARNING]
+> This benchmark is currently a Work In Progress (WIP). Expected bandwidth numbers are not yet finalized.
+
+## Create Node Pools
+
+Follow [Setup section](../../Ironwood_Microbenchmarks_readme.md#setup) to create a GKE cluster with one 2x2x1 nodepool.
+
+## Run Host Device Microbenchmarks
+
+To run the microbenchmarks, apply the following Kubernetes configuration:
+```bash
+kubectl apply -f tpu7x-host-device-benchmark.yaml
+```
+
+To extract the log of the microbenchmark, use `kubectl logs`:
+```bash
+kubectl logs tpu7x-host-device-benchmark
+```
+
+Once the benchmark completes, you should see logs reporting bandwidth statistics.
+
+To retrieve the complete results, including the trace and CSV output files, you must keep the pod running after the benchmark completes. To do this, add a `sleep` command to the `tpu7x-host-device-benchmark.yaml` file. You can then use `kubectl cp` to copy the output from the pod.
+
+```bash
+kubectl cp tpu7x-host-device-benchmark:/microbenchmarks/host_device host_device
+```

--- a/microbenchmarks/ironwood/host_device/tpu7x-host-device-benchmark.yaml
+++ b/microbenchmarks/ironwood/host_device/tpu7x-host-device-benchmark.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tpu7x-host-device-benchmark
+spec:
+  restartPolicy: Never
+  nodeSelector:
+    cloud.google.com/gke-tpu-accelerator: tpu7x
+    cloud.google.com/gke-tpu-topology: 2x2x1
+  containers:
+  - name: tpu-job
+    image: python:3.12
+    ports:
+    - containerPort: 8431
+    securityContext:
+      privileged: false
+    command:
+    - bash
+    - -c
+    - |
+      set -ex
+
+      git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+      cd accelerator-microbenchmarks
+      pip install -r requirements.txt
+
+      bash ./Ironwood/scripts/run_host_device_benchmark.sh --config Ironwood/configs/host_device/host_device.yaml
+
+    resources:
+      requests:
+        google.com/tpu: 4
+      limits:
+        google.com/tpu: 4

--- a/microbenchmarks/ironwood/inference/attention.MD
+++ b/microbenchmarks/ironwood/inference/attention.MD
@@ -1,0 +1,85 @@
+# Inference Attention Microbenchmarks
+This microbenchmark captures the performance of the Ragged-Paged Attention (RPAv3) kernel, with proper tuning.
+
+## Prerequisites and Setup
+
+Please follow the instructions located [here](https://github.com/AI-Hypercomputer/accelerator-microbenchmarks/blob/main/Ironwood/Ironwood_Microbenchmarks_readme.md#prerequisites) to set up GKE and [here](https://github.com/AI-Hypercomputer/accelerator-microbenchmarks/blob/main/Ironwood/Ironwood_Microbenchmarks_readme.md#setup) to setup your specific GKE resources.
+
+## Running the Infernece Attention Microbenchmarks in a GKE cluster
+
+Get credentials for the GKE cluster:
+
+```bash
+gcloud container clusters get-credentials ${CLUSTER_NAME} --location ${LOCATION} --project ${PROJECT_ID}
+```
+
+Verify that you have sufficient `gke-tpu-.*` nodes:
+
+```bash
+kubectl get nodes
+```
+
+### Deploying a single host job
+
+Create a job manifest to run `2x2x1` microbenchmarks (`tpu7x-2x2x1-inference-attention-microbenchmark.yaml`):
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tpu7x-single-host-microbenchmark
+spec:
+  restartPolicy: Never
+  nodeSelector:
+    cloud.google.com/gke-tpu-accelerator: tpu7x
+    cloud.google.com/gke-tpu-topology: 2x2x1
+  containers:
+  - name: tpu-job
+    image: vllm/vllm-tpu:ironwood
+    ports:
+    - containerPort: 8431
+    securityContext:
+      privileged: false
+    command:
+    - bash
+    - -c
+    - |
+      set -ex
+      git clone https://github.com/vllm-project/tpu-inference.git
+      cd tpu-inference
+      git checkout jacobplatin/janus-benchmarking-ext
+      pip install tensorflow
+      python benchmarking/benchmark_janus.py
+    resources:
+      requests:
+        google.com/tpu: 4
+      limits:
+        google.com/tpu: 4
+```
+
+> **_NOTE:_** the `python benchmarking/benchmark_janus.py` accepts the following flags:
+>
+> * `is_prefill`: Set to true to run prefill configs (defauls to `False`).
+> * `outdir`: Directory to save results and profiles (defaults to `benchmark-results`).
+
+Deploy the 2x2x1 inference attention microbenchmarks:
+
+```bash
+kubectl apply -f tpu7x-2x2x1-inference-attention-microbenchmark.yaml
+```
+
+Monitor the results:
+
+```bash
+kubectl logs -f tpu7x-single-host-microbenchmark
+```
+
+Cleanup the job:
+
+```bash
+kubectl delete pod tpu7x-single-host-microbenchmark
+```
+
+## Examine the outputs
+
+The benchmarks will print metrics to the terminal.  In addition, the traces and a CSV with all results will be saved to `outdir` (see above).

--- a/microbenchmarks/ironwood/inference/tpu7x-2x2x1-inference-attention-microbenchmark.yaml
+++ b/microbenchmarks/ironwood/inference/tpu7x-2x2x1-inference-attention-microbenchmark.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tpu7x-single-host-microbenchmark
+spec:
+  restartPolicy: Never
+  nodeSelector:
+    cloud.google.com/gke-tpu-accelerator: tpu7x
+    cloud.google.com/gke-tpu-topology: 2x2x1
+  containers:
+  - name: tpu-job
+    image: vllm/vllm-tpu:ironwood
+    ports:
+    - containerPort: 8431
+    securityContext:
+      privileged: false
+    command:
+    - bash
+    - -c
+    - |
+      set -ex
+      git clone https://github.com/vllm-project/tpu-inference.git
+      cd tpu-inference
+      git checkout jacobplatin/janus-benchmarking-ext
+      pip install tensorflow
+      python benchmarking/benchmark_janus.py
+    resources:
+      requests:
+        google.com/tpu: 4
+      limits:
+        google.com/tpu: 4

--- a/microbenchmarks/ironwood/matmul/tpu7x-2x2x1-matmul-microbenchmark.yaml
+++ b/microbenchmarks/ironwood/matmul/tpu7x-2x2x1-matmul-microbenchmark.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tpu7x-2x2x1-matmul-microbenchmark
+spec:
+  restartPolicy: Never
+  nodeSelector:
+    cloud.google.com/gke-tpu-accelerator: tpu7x
+    cloud.google.com/gke-tpu-topology: 2x2x1
+  containers:
+  - name: tpu-job
+    image: python:3.12
+    ports:
+    - containerPort: 8431
+    securityContext:
+      privileged: false
+    command:
+    - bash
+    - -c
+    - |
+      set -ex
+
+      git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
+      cd accelerator-microbenchmarks
+      pip install -r requirements.txt
+
+      python Ironwood/src/run_benchmark.py --config="Ironwood/configs/training/gemm_multiple_run.yaml"
+
+    resources:
+      requests:
+        google.com/tpu: 4
+      limits:
+        google.com/tpu: 4


### PR DESCRIPTION
Copy the Ironwood microbenchmark recipes from https://github.com/AI-Hypercomputer/accelerator-microbenchmarks/tree/tpu7x-auto/Ironwood.
Same as other TPU recipes, only the config and run scripts are kept in this repo.