### PR TITLE
Add Wan 2.2 Text-to-Video (T2V) Inference Recipe for Ironwood (TPU v7x)

### DIFF
--- a/inference/ironwood/MaxDiffusion/Wan2.x/Wan2.2-T2V/README.md
+++ b/inference/ironwood/MaxDiffusion/Wan2.x/Wan2.2-T2V/README.md
@@ -1,0 +1,357 @@
+# Inference Wan-AI/Wan2.2-T2V-27B-Diffusers workload on Ironwood GKE clusters with XPK.
+
+This recipe outlines the steps for running a maxdiffusion
+[Maxdiffusion](https://github.com/AI-Hypercomputer/maxdiffusion) inference workload on
+[Ironwood GKE clusters](https://cloud.google.com/kubernetes-engine) by using
+[XPK](https://github.com/AI-Hypercomputer/xpk).
+
+## Workload Details
+
+This workload is configured with the following details:
+
+-   Model: Wan 2.2 Text-to-Video (T2V) 27B
+-   num_frames: 81
+-   width: 1280 (720p) or 832 (480p)
+-   height: 720 (720p) or 480 (480p)
+-   num_inference_steps: 40
+-   fps: 16
+-   TPU Cores: 7x-8, 7x-16
+
+## Prerequisites
+
+To run this recipe, you need the following:
+
+-   **GCP Project Setup:** Ensure you have a GCP project with billing enabled
+    and have access to Ironwood.
+-   **User Project Permissions:** The account used requires the following IAM
+    Roles:
+    -   Artifact Registry Writer
+    -   Compute Admin
+    -   Kubernetes Engine Admin
+    -   Logging Admin
+    -   Monitoring Admin
+    -   Service Account User
+    -   Storage Admin
+    -   Vertex AI Administrator
+    -   Service Usage Consumer
+    -   TPU Viewer
+-   **Docker:** Docker must be installed on your workstation. Follow the steps
+    in the [Install XPK and dependencies](#install-xpk-and-dependencies) section
+    to install Docker.
+-   **Python 3.12 Virtual Environment:** A Python
+    3.12 virtual environment is required. Instructions
+    for setting this up are also in the
+    [Install XPK and dependencies](#install-xpk-and-dependencies) section.
+-   **XPK and Dependencies:** Follow the steps in the
+    [Install XPK and dependencies](#install-xpk-and-dependencies) section to
+    install XPK, `kubectl`, `kubectl-kueue`, and `kubectl-kjob`.
+
+## Install XPK and dependencies
+
+### XPK and Dependency Installation
+
+#### Virtual Python Environment
+
+Run the following to create a virtual Python environment:
+
+```bash
+# Set up uv
+sudo apt update
+curl -LsSf https://astral.sh/uv/install.sh -o install-uv.sh
+chmod +x install-uv.sh
+./install-uv.sh
+rm install-uv.sh
+source ${HOME}/.local/bin/env
+
+# Set up and Activate Python 3.12 virtual environment
+uv venv --seed ${HOME}/.local/bin/venv --python 3.12 --clear
+source ${HOME}/.local/bin/venv/bin/activate
+pip install --upgrade pip
+```
+
+#### XPK
+
+Make sure you have the virtual environment activated when running XPK.
+
+Install XPK and necessary tools:
+
+```bash
+# Install gcloud, if not already installed, https://cloud.google.com/sdk/docs/install
+# Install kubectl, if not already installed, https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl#install_kubectl
+
+# Ensure to log in to your gcloud
+
+# Install latest xpk
+pip install xpk==1.3.0
+
+# Install xpk pre-reqs kubectl-kueue and kjob (if you installed xpk via pip)
+curl -LsSf https://raw.githubusercontent.com/AI-Hypercomputer/xpk/refs/tags/v1.3.0/tools/install-xpk.sh -o install-xpk.sh
+chmod +x install-xpk.sh
+sudo ./install-xpk.sh
+rm install-xpk.sh
+
+# Follow https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl#install_plugin to install gke-gcloud-auth-plugin
+```
+
+#### Docker
+
+Install Docker using instructions provided by your administrator. Once
+installed, run the following commands:
+
+```bash
+## Configure docker and test installation
+gcloud auth configure-docker
+sudo usermod -aG docker $USER ## relaunch the terminal and make sure you have the virtual environment activated after running this command
+docker run hello-world # Test docker
+```
+
+## Orchestration and deployment tools
+
+For this recipe, the following setup is used:
+
+-   **Orchestration** -
+    [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine)
+-   **Inference job configuration and deployment** - XPK is used to configure
+    and deploy the
+    [Kubernetes Jobset](https://kubernetes.io/blog/2025/03/23/introducing-jobset)
+    resource, which manages the execution of the Maxdiffusion Wan models.
+
+## Test environment
+
+This recipe is tested with `7x-8` and `7x-16`.
+
+-   **GKE cluster** To create your GKE cluster, use the XPK instructions.
+    [XPK instructions](https://github.com/AI-Hypercomputer/xpk?tab=readme-ov-file#cluster-create).
+    A sample command to create an XPK cluster is provided below.
+
+### Environment Variables for Cluster Creation
+
+The environment variables required for cluster creation and workload execution
+are defined at the beginning of the `run_recipe.sh` script. **Before running the
+`xpk workload create` command**, please open `run_recipe.sh` and modify the
+`export` statements to set these variables to match your environment. It is
+crucial to use consistent values for `PROJECT_ID`, `CLUSTER_NAME`, and `ZONE`
+across all commands and configurations.
+
+-   `PROJECT_ID`: Your GCP project name.
+-   `CLUSTER_NAME`: The target cluster name.
+-   `ZONE`: The zone for your cluster (e.g., `us-central1-c`).
+-   `CONTAINER_REGISTRY`: The container registry to use (e.g., `gcr.io`).
+-   `BASE_OUTPUT_DIR`: Output directory for model logs/artifacts (e.g.,
+    `"gs://<your_gcs_bucket>"`).
+-   `WORKLOAD_IMAGE`: The Docker image for the workload. This is set to a placeholder
+    `<YOUR_CONTAINER_REGISTRY>/<YOUR_PROJECT_ID>/<YOUR_IMAGE_NAME>:latest` by default.
+-   `WORKLOAD_NAME`: A unique name for your workload. This is set in
+    `run_recipe.sh` using the following command:
+    `export WORKLOAD_NAME="$(printf "%.26s" "${USER//_/-}-wan2-2-t2v")-$(date +%Y%m%d-%H%M)"`
+-   `GKE_VERSION`: The GKE version, `1.34.0-gke.2201000` or later.
+-   `ACCELERATOR_TYPE`: The TPU type (e.g., `tpu7x-2x2x1` or `tpu7x-2x2x2`). See topologies
+    [here](https://cloud.google.com/kubernetes-engine/docs/concepts/plan-tpus#configuration).
+-   `RESERVATION_NAME`: Your TPU reservation name. Use the reservation name if
+    within the same project. For a shared project, use
+    `"projects/<project_number>/reservations/<reservation_name>"`.
+
+If you don't have a GCS bucket, create one with this command:
+
+```bash
+# Make sure BASE_OUTPUT_DIR is set in run_recipe.sh before running this.
+gcloud storage buckets create ${BASE_OUTPUT_DIR} --project=${PROJECT_ID} --location=US  --default-storage-class=STANDARD --uniform-bucket-level-access
+```
+
+### Sample XPK Cluster Creation Command
+
+```bash
+xpk cluster create \
+  --cluster=${CLUSTER_NAME} \
+  --project=${PROJECT_ID} \
+  --zone=${ZONE} \
+  --device-type=${ACCELERATOR_TYPE} \
+  --num-slices=1 \
+  --reservation=${RESERVATION_NAME}
+```
+
+## Docker container image
+
+To build your own image, follow the steps linked in this section. If you don't
+have Docker installed on your workstation, see the section below for installing
+XPK and its dependencies. Docker installation is part of this process.
+
+### Steps for building workload image
+
+The following software versions are used:
+
+-   Libtpu version: 0.0.40 or nightly
+-   Jax version: 0.10.0 or nightly
+-   MaxDiffusion version: git+https://github.com/AI-Hypercomputer/maxdiffusion.git
+-   Python: 3.12
+-   XPK: 1.3.0
+
+Docker Image Building Command:
+
+```bash
+export CONTAINER_REGISTRY="" # Initialize with your registry
+export CLOUD_IMAGE_NAME="${USER}-maxdiffusion-runner"
+export WORKLOAD_IMAGE="${CONTAINER_REGISTRY}/${PROJECT_ID}/${CLOUD_IMAGE_NAME}"
+export PROJECT_ID=<YOUR_PROJECT_ID>
+
+# Clone MaxDiffusion Repository
+git clone https://github.com/AI-Hypercomputer/maxdiffusion.git
+cd maxdiffusion
+
+# Build and upload the docker image
+bash docker_build_dependency_image.sh
+
+# Connect to your project
+gcloud config set project ${PROJECT_ID}
+
+# Upload the image to your project's docker registry with the name ${CLOUD_IMAGE_NAME}
+bash docker_upload_runner.sh CLOUD_IMAGE_NAME=${CLOUD_IMAGE_NAME}
+```
+
+## Testing prompt
+
+This recipe uses a single prompt for testing video generation speed.
+
+## Run the recipe
+
+### Configure environment settings
+
+Before running any commands in this section, ensure you have set the environment
+variables as described in
+[Environment Variables for Cluster Creation](#environment-variables-for-cluster-creation).
+
+### Connect to an existing cluster (Optional)
+
+If you want to connect to your GKE cluster to see its current state before
+running the benchmark, you can use the following gcloud command (note that XPK
+does this for you already):
+
+```bash
+gcloud container clusters get-credentials ${CLUSTER_NAME} --project ${PROJECT_ID} --zone ${ZONE}
+```
+
+## Get the recipe
+```bash
+cd ~
+git clone https://github.com/ai-hypercomputer/tpu-recipes.git
+cd tpu-recipes/inference/ironwood/MaxDiffusion/Wan2.x/Wan2.2-T2V
+```
+
+### Run Maxdiffusion inference Workload
+
+The `run_recipe.sh` script contains all the necessary environment variables and
+configurations to launch the Wan inference workload.
+
+Before execution, use `nano ./run_recipe.sh` to edit the script and configure the environment variables to match your specific environment.
+
+To configure and run the benchmark:
+
+```bash
+# --- Environment Variables ---
+export PROJECT_ID=<YOUR_PROJECT_ID>
+export CLUSTER_NAME=<YOUR_CLUSTER_NAME>
+export ZONE=<YOUR_CLUSTER_ZONE>
+export BASE_OUTPUT_DIR="" # E.g. gs://<YOUR_BUCKET_NAME>
+export HF_TOKEN=<YOUR_HF_TOKEN>
+export TPU_TYPE=<YOUR_HARDWARE_TYPE> # Supported values: 7x-8, 7x-16 (or exact TPU topologies: tpu7x-2x2x1, tpu7x-2x2x2)
+export RESOLUTION=<720p or 480p> # Supported: 720p, 480p (Defaults to 720p)
+export UV_VENV_PATH="${UV_VENV_PATH:-${HOME}/.local/bin/venv}"
+export WORKLOAD_IMAGE=<YOUR_WORKLOAD_IMAGE> # E.g. gcr.io/<YOUR_PROJECT_ID>/<YOUR_IMAGE_NAME> or nightly pre-built image
+
+chmod +x run_recipe.sh
+nano ./run_recipe.sh
+./run_recipe.sh
+```
+
+You can customize the run by modifying `run_recipe.sh`:
+
+-   **Environment Variables:** Adjust environmental variables like `PROJECT_ID`,
+    `CLUSTER_NAME`, `ZONE`, `WORKLOAD_NAME`, `WORKLOAD_IMAGE`, and `BASE_OUTPUT_DIR`
+    to match your environment.
+-   **XLA Flags:** The `XLA_FLAGS` variable contains a set of XLA configurations
+    optimized for Ironwood TPUs. These can be tuned for performance or
+    debugging.
+-   **MaxDiffusion Workload Overrides:** The `MAXDIFFUSION_ARGS` variable holds the
+    arguments passed to the `python src/maxdiffusion/generate_wan.py` command. This
+    includes model-specific settings like `per_device_batch_size`,
+    `num_inference_steps`, and others. You can modify these to experiment with
+    different model configurations.
+-   **Virtual Environment:** The script activates the virtual environment
+    created during the
+    [Install XPK and dependencies](#install-xpk-and-dependencies) steps. If you
+    used a different virtual environment, modify the `source` command at the top
+    of `run_recipe.sh`.
+
+Note that any MaxDiffusion configurations not explicitly overridden in `MAXDIFFUSION_ARGS`
+are expected to use the defaults within the specified `WORKLOAD_IMAGE`.
+
+
+## Monitor the job
+
+To monitor your job's progress, you can use kubectl to check the Jobset status
+and stream logs:
+
+```bash
+kubectl get jobset -n default ${WORKLOAD_NAME}
+
+# List pods to find the specific name (e.g., ${WORKLOAD_NAME}-0-0-xxxx)
+kubectl get pods | grep ${WORKLOAD_NAME}
+```
+Then, stream the logs from the running pod (replace <POD_NAME> with the name you found):
+
+```bash
+kubectl logs -f <POD_NAME>
+```
+You can also monitor your cluster and TPU usage through the Google Cloud
+Console.
+
+### Follow Workload and View Metrics
+
+After running `xpk workload create`, you will get a link to the Google Cloud
+Console to view your workload logs. Example: `[XPK] Follow your workload here:
+https://console.cloud.google.com/kubernetes/service/${ZONE}/${PROJECT_ID}/default/${WORKLOAD_NAME}/details?project=${PROJECT_ID}`
+Alternatively, list workloads: (`xpk workload list`)
+
+```bash
+xpk workload list --cluster ${CLUSTER_NAME} --project ${PROJECT_ID} --zone ${ZONE}
+```
+
+For more in-depth debugging, use xpk inspector: (`xpk inspector`)
+
+```bash
+xpk inspector --cluster ${CLUSTER_NAME} --project ${PROJECT_ID} --zone ${ZONE} [--workload ${WORKLOAD_NAME}]
+```
+
+### Delete resources
+
+#### Delete a specific workload
+
+```bash
+xpk workload delete --workload ${WORKLOAD_NAME} --cluster ${CLUSTER_NAME} --project ${PROJECT_ID} --zone ${ZONE}
+# Or filter and delete:
+xpk workload delete --cluster ${CLUSTER_NAME} --project ${PROJECT_ID} --zone ${ZONE} --filter-by-job=${USER}
+```
+
+#### Delete the entire XPK cluster
+
+```bash
+xpk cluster delete --cluster ${CLUSTER_NAME} --zone ${ZONE} --project ${PROJECT_ID}
+```
+
+## Check results
+
+After the job completes, you can check the results by:
+
+-   Video generated can be found in the Google Cloud Storage bucket specified by the
+    `${BASE_OUTPUT_DIR}/${WORKLOAD_NAME}` variable.
+-   Per video generation time (throughput) can be found by extracting the tensorboard content
+    using event_accumulator inside tensorboard.backend.event_processing.
+-   Accessing output logs from your job.
+
+
+## Next steps: deeper exploration and customization
+
+This recipe is designed to provide a simple, reproducible "0-to-1" experience
+for running a Maxdiffusion inference workload on Ironwood. Its primary purpose is to help you
+verify your environment and achieve a first success with TPUs quickly and
+reliably.

--- a/inference/ironwood/MaxDiffusion/Wan2.x/Wan2.2-T2V/run_recipe.sh
+++ b/inference/ironwood/MaxDiffusion/Wan2.x/Wan2.2-T2V/run_recipe.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+set -e
+
+# --- Environment Setup ---
+# This script requires uv and a Python virtual environment with xpk installed.
+# If you haven't set up uv and the environment, please refer to the README.md.
+
+# Activate the virtual environment
+export UV_VENV_PATH="${UV_VENV_PATH:-${HOME}/.local/bin/venv}"
+if [ -f "${UV_VENV_PATH}/bin/activate" ]; then
+    source "${UV_VENV_PATH}/bin/activate"
+else
+    echo "Error: Virtual environment not found at ${UV_VENV_PATH}. Check README.md."
+    exit 1
+fi
+
+# Check if xpk is installed in the venv
+if ! pip show xpk &> /dev/null; then
+    echo "xpk not found in the virtual environment. Please install it by running:"
+    echo "pip install xpk==1.3.0"
+    exit 1
+fi
+
+# --- End Environment Setup ---
+
+# --- Configuration ---
+# Before running this script, please modify the environment variables below
+# to match your specific GCP project and cluster setup.
+# ---
+
+# Environmental Variables
+export PROJECT_ID="${PROJECT_ID}"
+export CLUSTER_NAME="${CLUSTER_NAME}"
+export ZONE="${ZONE}"
+export BASE_OUTPUT_DIR="${BASE_OUTPUT_DIR}"
+export HF_TOKEN="${HF_TOKEN}"
+export TPU_TYPE="${TPU_TYPE:-7x-8}"
+export RESOLUTION="${RESOLUTION:-720p}"
+
+export WORKLOAD_IMAGE="${WORKLOAD_IMAGE:-<YOUR_CONTAINER_REGISTRY>/<YOUR_PROJECT_ID>/<YOUR_IMAGE_NAME>:latest}"
+random_suffix=$(tr -dc 'a-z0-9' < /dev/urandom | head -c 5)
+export WORKLOAD_NAME="${WORKLOAD_NAME:-$(printf "%.20s" "${USER//_/-}-wan2-2-t2v")-${random_suffix}-$(date +%Y%m%d-%H%M)}"
+export BASE_YAML_CONFIG="src/maxdiffusion/configs/base_wan_27b.yml"
+export SCRIPT_PATH="src/maxdiffusion/generate_wan.py"
+
+# Default COMMAND_PREFIX tailored for Ironwood (7x)
+export COMMAND_PREFIX="bash setup.sh MODE=stable DEVICE=tpu && pip install jax[tpu]==0.10.0 && pip install -e . --no-deps && export HF_HUB_CACHE=/dev/shm && export HF_HUB_ENABLE_HF_TRANSFER=1 && export TORCHINDUCTOR_FREEZING=1 && export TORCHINDUCTOR_CPP_WRAPPER=1 && export TORCHINDUCTOR_MEMORY_PLANNING=1 && export JAX_PERSISTENT_CACHE_MIN_ENTRY_SIZE_BYTES=-1 && export JAX_PERSISTENT_CACHE_MIN_COMPILE_TIME_SECS=0 && export XLA_PYTHON_CLIENT_MEM_FRACTION=0.95 && export JAX_DEFAULT_MATMUL_PRECISION=bfloat16"
+
+# XLA Flags optimized for Ironwood
+XLA_FLAGS="'\"'\"' \
+--xla_tpu_dvfs_p_state=7 \
+--xla_tpu_spmd_rng_bit_generator_unsafe=true \
+--xla_tpu_enable_dot_strength_reduction=true \
+--xla_tpu_enable_async_collective_fusion_fuse_all_gather=true \
+--xla_enable_async_collective_permute=true \
+--xla_tpu_enable_data_parallel_all_reduce_opt=true \
+--xla_tpu_data_parallel_opt_different_sized_ops=true \
+--xla_tpu_enable_async_collective_fusion=true \
+--xla_tpu_enable_async_collective_fusion_multiple_steps=true \
+--xla_tpu_overlap_compute_collective_tc=true \
+--xla_enable_async_all_gather=true \
+--xla_tpu_enable_async_all_to_all=true \
+--xla_tpu_enable_all_experimental_scheduler_features=true \
+--xla_tpu_enable_scheduler_memory_pressure_tracking=true \
+--xla_tpu_host_transfer_overlap_limit=24 \
+--xla_max_concurrent_host_send_recv=100 \
+--xla_tpu_scheduler_percent_shared_memory_limit=100 \
+--xla_latency_hiding_scheduler_rerun=2 \
+--xla_tpu_use_minor_sharding_for_major_trivial_input=true \
+--xla_tpu_relayout_group_size_threshold_for_reduce_scatter=1 \
+--xla_tpu_enable_latency_hiding_scheduler=true \
+--xla_tpu_memory_bound_loop_optimizer_options=enabled:true \
+--xla_tpu_use_single_sparse_core_for_all_gather_offload=true \
+--xla_tpu_sparse_core_all_gather_latency_multiplier=1 \
+--xla_tpu_sparse_core_reduce_scatter_latency_multiplier=3 \
+--xla_tpu_enable_sparse_core_collective_aggregator=true \
+--xla_tpu_enable_sparse_core_offload_queuing_in_lhs=true \
+--xla_tpu_enable_sparse_core_reduce_scatter_v2=true \
+--xla_tpu_enable_sparse_core_collective_offload_all_gather=true \
+--xla_tpu_enable_sparse_core_collective_offload_2d_all_gather=true \
+--xla_tpu_enable_sparse_core_collective_offload_all_reduce=true \
+--xla_tpu_enable_sparse_core_collective_offload_reduce_scatter=true \
+--xla_tpu_enable_sparse_core_collective_offload_3d_all_gather=true \
+--xla_tpu_enable_concurrent_sparse_core_offloading=true \
+--xla_tpu_assign_all_reduce_scatter_layout=true'\"'\"'"
+
+# Resolution Configuration
+case "$RESOLUTION" in
+    "720p")
+        WIDTH=1280
+        HEIGHT=720
+        ;;
+    "480p")
+        WIDTH=832
+        HEIGHT=480
+        ;;
+    *)
+        echo "Error: Unsupported resolution '$RESOLUTION'. Supported resolutions: 720p, 480p"
+        exit 1
+        ;;
+esac
+
+# Topology and Parallelism Configuration
+# Note: TPU 7x has 2 cores per physical chip.
+# - 7x-8 represents 8 TPU cores (4 physical chips with a 2x2x1 GKE topology)
+# - 7x-16 represents 16 TPU cores (8 physical chips with a 2x2x2 GKE topology)
+case "$TPU_TYPE" in
+    "7x-8" | "tpu7x-2x2x1")
+        XPK_TPU_TYPE="tpu7x-2x2x1"
+        ICI_DATA_PARALLELISM=2
+        ICI_CONTEXT_PARALLELISM=4
+        PER_DEVICE_BATCH_SIZE=0.125
+        ;;
+    "7x-16" | "tpu7x-2x2x2")
+        XPK_TPU_TYPE="tpu7x-2x2x2"
+        ICI_DATA_PARALLELISM=2
+        ICI_CONTEXT_PARALLELISM=8
+        PER_DEVICE_BATCH_SIZE=0.0625
+        ;;
+    *)
+        echo "Error: Unsupported TPU_TYPE '$TPU_TYPE'. Supported values: 7x-8, 7x-16"
+        exit 1
+        ;;
+esac
+
+# MaxDiffusion Workload Overrides
+MAXDIFFUSION_ARGS="\
+model_name='\"'\"'wan2.2'\"'\"' \
+attention='\"'\"'ulysses_custom'\"'\"' \
+num_frames=81 \
+width=${WIDTH} \
+height=${HEIGHT} \
+per_device_batch_size=${PER_DEVICE_BATCH_SIZE} \
+vae_spatial=4 \
+vae_decode_chunk=-1 \
+vae_weights_dtype='bfloat16' \
+vae_dtype='bfloat16' \
+text_encoder_dtype='bfloat16' \
+compile_text_encoder=true \
+ici_data_parallelism=${ICI_DATA_PARALLELISM} \
+ici_context_parallelism=${ICI_CONTEXT_PARALLELISM} \
+fps=16 \
+use_kv_cache=True \
+use_base2_exp=True \
+use_experimental_scheduler=True \
+use_batched_text_encoder=false \
+flash_block_sizes='\"'\"'{\"block_kv\":1024,\"block_kv_compute\":1024,\"block_kv_compute_in\":1024,\"block_kv_dkv\":1024,\"block_kv_dkv_compute\":1024,\"block_q\":4864,\"block_q_dkv\":4864,\"block_q_dq\":4864,\"heads_per_tile\":1}'\"'\"' \
+base_output_directory='\"'\"'${BASE_OUTPUT_DIR}/${WORKLOAD_NAME}'\"'\"' \
+output_dir='\"'\"'${BASE_OUTPUT_DIR}/${WORKLOAD_NAME}'\"'\"' \
+run_name='\"'\"'${WORKLOAD_NAME}'\"'\"'"
+
+echo "Deploying workload via xpk..."
+
+cmd="xpk workload create \
+  --cluster=$CLUSTER_NAME \
+  --project=$PROJECT_ID \
+  --zone=$ZONE \
+  --priority=very-high \
+  --max-restarts=0 \
+  --tpu-type=$XPK_TPU_TYPE \
+  --num-slices=1 \
+  --docker-image=\"${WORKLOAD_IMAGE}\" \
+  --enable-debug-logs \
+  --workload=\"${WORKLOAD_NAME}\" \
+  --command='set -e && \
+export ARTIFACT_DIR=${BASE_OUTPUT_DIR}/${WORKLOAD_NAME} && \
+export OUTPUT_DIR=${BASE_OUTPUT_DIR}/${WORKLOAD_NAME} && \
+export LIBTPU_INIT_ARGS=${XLA_FLAGS} && \
+${COMMAND_PREFIX} && export HF_TOKEN=${HF_TOKEN} && \
+  python ${SCRIPT_PATH}  \
+  ${BASE_YAML_CONFIG} \
+  ${MAXDIFFUSION_ARGS}'"
+
+eval ${cmd}


### PR DESCRIPTION
#### **Overview**
This PR adds a new inference recipe for the **Wan 2.2 Text-to-Video (T2V) 27B** model on Google Cloud TPU v7x (Ironwood) GKE clusters using XPK.
The recipe contains both the configuration deployment script and a detailed walkthrough README.
#### **Files Added**
- **run_recipe.sh**: A configurable shell script that builds commands and deploys workload runs onto the GKE cluster using `xpk workload create`.
- **README.md**: Walkthrough outlining virtual environment setup (using Python 3.12 and `uv`), dependency installation, cluster requirements, Docker image uploads, execution steps, and metric monitoring.
#### **Workload Details**
- **Model:** Wan 2.2 Text-to-Video (T2V) 27B
- **num_frames:** 81
- **num_inference_steps:** 40
- **fps:** 16
- **width:** 1280 (720p) or 832 (480p)
- **height:** 720 (720p) or 480 (480p)
- **TPU Devices:** `v7x-8` and `v7x-16` 
#### **Key Features**
1. **Explicit Topology Mappings:** Configured optimized parallelism meshes for the target topologies:
   - **`v7x-8`**: `ici_data_parallelism=2`, `ici_context_parallelism=4`, `per_device_batch_size=0.125`
   - **`v7x-16`**: `ici_data_parallelism=2`, `ici_context_parallelism=8`, `per_device_batch_size=0.0625`
2. **Resolution Parameterization:** Dynamically configures and overrides resolution arguments inside the script (supporting `720p` and `480p`, defaulting to `720p`).
3. **Optimized XLA Flags:** Tailored compile flags specifically tuned for Wan 2.2 on Ironwood.
