### PR TITLE
Add optimized Gemma4 config

### DIFF
--- a/inference/ironwood/vLLM/Gemma4/README.md
+++ b/inference/ironwood/vLLM/Gemma4/README.md
@@ -116,15 +116,16 @@ First, download the client code: `git clone https://github.com/SemiAnalysisAI/In
 
 1. Execute a short benchmark against the server using one of the following workloads.
 
-    #### Workload 1k/1k
+    #### Workload 1k/500
 
-    Save the following manifest as `vllm-benchmark-1k1k.yaml` and apply it using `kubectl apply -f vllm-benchmark-1k1k.yaml`.
+    Save the following manifest as `vllm-benchmark-1k500.yaml` and apply it using `kubectl apply -f vllm-benchmark-1k500.yaml`.
 
     ```yaml
     apiVersion: v1
     kind: Pod
     metadata:
-      name: vllm-bench-1k1k
+      name: vllm-bench-1k500
+      namespace: gemma4-test
     spec:
       terminationGracePeriodSeconds: 60
       containers:
@@ -139,17 +140,14 @@ First, download the client code: `git clone https://github.com/SemiAnalysisAI/In
           python3 /ubench/inferencex/utils/bench_serving/benchmark_serving.py \
             --backend=vllm \
             --request-rate=inf \
-            --percentile-metrics='ttft,tpot,itl,e2el' \
             --host=vllm-service \
             --port=8000 \
             --model=google/gemma-4-31B-it \
             --tokenizer=google/gemma-4-31B-it \
             --dataset-name=random \
             --random-input-len=1024 \
-            --random-output-len=1024 \
-            --random-range-ratio=0.8 \
-            --num-prompts=320 \
-            --max-concurrency=64 \
+            --random-output-len=500 \
+            --num-prompts=1280 \
             --ignore-eos
         env:
         - name: HUGGING_FACE_HUB_TOKEN
@@ -168,6 +166,7 @@ First, download the client code: `git clone https://github.com/SemiAnalysisAI/In
     kind: Pod
     metadata:
       name: vllm-bench-1k8k
+      namespace: gemma4-test
     spec:
       terminationGracePeriodSeconds: 60
       containers:
@@ -182,7 +181,6 @@ First, download the client code: `git clone https://github.com/SemiAnalysisAI/In
           python3 /ubench/inferencex/utils/bench_serving/benchmark_serving.py \
             --backend=vllm \
             --request-rate=inf \
-            --percentile-metrics='ttft,tpot,itl,e2el' \
             --host=vllm-service \
             --port=8000 \
             --model=google/gemma-4-31B-it \
@@ -192,7 +190,6 @@ First, download the client code: `git clone https://github.com/SemiAnalysisAI/In
             --random-output-len=8192 \
             --random-range-ratio=0.8 \
             --num-prompts=320 \
-            --max-concurrency=64 \
             --ignore-eos
         env:
         - name: HUGGING_FACE_HUB_TOKEN
@@ -211,6 +208,7 @@ First, download the client code: `git clone https://github.com/SemiAnalysisAI/In
     kind: Pod
     metadata:
       name: vllm-bench-8k1k
+      namespace: gemma4-test
     spec:
       terminationGracePeriodSeconds: 60
       containers:
@@ -225,7 +223,6 @@ First, download the client code: `git clone https://github.com/SemiAnalysisAI/In
           python3 /ubench/inferencex/utils/bench_serving/benchmark_serving.py \
             --backend=vllm \
             --request-rate=inf \
-            --percentile-metrics='ttft,tpot,itl,e2el' \
             --host=vllm-service \
             --port=8000 \
             --model=google/gemma-4-31B-it \
@@ -235,7 +232,6 @@ First, download the client code: `git clone https://github.com/SemiAnalysisAI/In
             --random-output-len=1024 \
             --random-range-ratio=0.8 \
             --num-prompts=320 \
-            --max-concurrency=64 \
             --ignore-eos
         env:
         - name: HUGGING_FACE_HUB_TOKEN
@@ -248,22 +244,42 @@ First, download the client code: `git clone https://github.com/SemiAnalysisAI/In
 2. Check the progress of benchmark:
 
     ```bash
-    kubectl logs -f vllm-bench-1k1k # For 1k/1k workload
+    kubectl logs -f vllm-bench-1k500 # For 1k/500 workload
     ```
 
     Example Output:
     ```
     ============ Serving Benchmark Result ============
-    Successful requests:                     320
-    Failed requests:                         0
-    Benchmark duration (s):                  xx
-    ...
+    Successful requests:                     1280
+    Benchmark duration (s):                  xx.xx
+    Total input tokens:                      xxxx
+    Total generated tokens:                  xxxx
+
+    Request throughput (req/s):              xx.xx
+    Output token throughput (tok/s):         xxxx.xx
+    Total Token throughput (tok/s):          xxxx.xx
+
+    ---------------Time to First Token----------------
+    Mean TTFT (ms):                          xxxx.xx
+    Median TTFT (ms):                        xxxx.xx
+    P99 TTFT (ms):                           xxxx.xx
+
+    -----Time per Output Token (excl. 1st token)------
+    Mean TPOT (ms):                          xx.xx
+    Median TPOT (ms):                        xx.xx
+    P99 TPOT (ms):                           xx.xx
+
+    ---------------Inter-token Latency----------------
+    Mean ITL (ms):                           xx.xx
+    Median ITL (ms):                         xx.xx
+    P99 ITL (ms):                            xx.xx
+    ==================================================
     ```
 
 3. Clean up
 
     ```bash
-    kubectl delete -f vllm-benchmark-1k1k.yaml
+    kubectl delete -f vllm-benchmark-1k500.yaml
     kubectl delete -f vllm-benchmark-1k8k.yaml
     kubectl delete -f vllm-benchmark-8k1k.yaml
     ```

--- a/inference/ironwood/vLLM/Gemma4/gemma4-server.yaml
+++ b/inference/ironwood/vLLM/Gemma4/gemma4-server.yaml
@@ -46,38 +46,40 @@ spec:
       # TODO: Update the topology to match your allocated TPU node pool (e.g., 2x2x1 is 4 chips)
       nodeSelector:
         cloud.google.com/gke-tpu-accelerator: tpu7x
-        cloud.google.com/gke-tpu-topology: 1x1x1
+        cloud.google.com/gke-tpu-topology: 2x2x1
       containers:
       - name: vllm-tpu
-        image: vllm/vllm-tpu:nightly-20260514-4690ef3-bf0d2dc
+        image: vllm/vllm-tpu:nightly-20260604-2aaa59e-4f423bd
         command: ["python3", "-m", "vllm.entrypoints.openai.api_server"]
 
         args:
         - --host=0.0.0.0
         - --port=8000
         - --seed=42
-        # TODO: Update tensor-parallel-size to match the number of chips in your topology
-        - --tensor-parallel-size=2
-        - --max-model-len=9216
-        - --max-num-batched-tokens=4096
-        - --block-size=256
-        - --download-dir=/data
-        - --no-enable-prefix-caching
-        - --additional_config='{"quantization": { "qwix": { "rules": [{ "module_path": ".*", "weight_qtype": "float8_e4m3fn", "act_qtype": "float8_e4m3fn"}]}}}'
         # TODO: Update the model if you wish to switch to MoE or another variant
         - --model=google/gemma-4-31B-it
+        - --max-model-len=1524
+        - --max-num-seqs=256
+        - --data-parallel-size=4
+        - --tensor-parallel-size=2
+        - --max-num-batched-tokens=16384
+        - --no-enable-prefix-caching
         - --kv-cache-dtype=fp8
+        - --gpu-memory-utilization=0.9
         - --async-scheduling
-        - --gpu-memory-utilization=0.90
-        - --disable_chunked_mm_input
-        - --enable-auto-tool-choice
-        - --tool-call-parser=gemma4
+        - "--limit-mm-per-prompt={\"image\": 0, \"video\": 0, \"audio\": 0}"
+        - --block-size=256
+        - "--additional-config={\"quantization\": { \"qwix\": { \"rules\": [{ \"module_path\": \".*\", \"weight_qtype\": \"float8_e4m3fn\", \"act_qtype\": \"float8_e4m3fn\"}]}}}"
 
         env:
+        - name: VLLM_ENGINE_READY_TIMEOUT_S
+          value: "1800"
+        - name: TPU_MULTIPROCESS_DP
+          value: "1"
         - name: USE_BATCHED_RPA_KERNEL
-          value: 1
-        - name: MOE_REQUANTIZE_WEIGHT_DTYPE
-          value: float8_e4m3fn
+          value: "1"
+        - name: MODEL_IMPL_TYPE
+          value: "flax_nnx"
         - name: HF_HOME
           value: /data
         - name: HF_TOKEN
@@ -90,9 +92,9 @@ spec:
         - containerPort: 8000
         resources:
           limits:
-            google.com/tpu: '1' # Number of chips required by topology
+            google.com/tpu: '4' # Number of chips required by topology
           requests:
-            google.com/tpu: '1'
+            google.com/tpu: '4'
         readinessProbe:
           tcpSocket:
             port: 8000


### PR DESCRIPTION

##### Change Description:

Updating Gemma4 31B recipe to use optimal config so that external customers can reproduce the same benchmarks independently.

##### Next Steps:
 - Once we have optimal config ready for 26B will create two separate sub-directories under Gemma4 with two different recipes (both representing optimal configs)


##### Testing
 - **Internal Testing**: Tested exact same config: 
   - runId: vllm_inference-gemma-4-31B-custom-2026-06-04_224743-a239a21a-1594-4591-b802-c0a16a61ad62
 
 - **Direct GKE Testing**:
   - Deployed directly on GKE cluster, following the steps mentioned in this recipe and was able to get the expected results.
