### PR TITLE
Feat(ironwood/vllm): add DeepSeek-R1 and DeepSeek-V3 serving recipes

### DIFF
--- a/inference/ironwood/vLLM/DeepSeek-R1/README.md
+++ b/inference/ironwood/vLLM/DeepSeek-R1/README.md
@@ -156,7 +156,7 @@ spec:
     command: ["/bin/bash", "-c"]
     args:
     - |
-      while ! curl -s http://vllm-deepseek-r1-service:8000/ping; do sleep 30 && echo 'Waiting for server...'; done
+      while ! curl -s -f http://vllm-deepseek-r1-service:8000/health; do sleep 30 && echo 'Waiting for server...'; done
       apt-get update && apt-get install -y git && \
       git clone https://github.com/SemiAnalysisAI/InferenceX.git /tmp/inferencex && \
       cd /tmp/inferencex && \

--- a/inference/ironwood/vLLM/DeepSeek-R1/README.md
+++ b/inference/ironwood/vLLM/DeepSeek-R1/README.md
@@ -1,8 +1,8 @@
-# Serve DeepSeek-R1 / DeepSeek-V3 with vLLM on Ironwood TPU
+# Serve DeepSeek-R1 with vLLM on Ironwood TPU
 
-In this guide, we show how to serve and benchmark [DeepSeek-R1](https://huggingface.co/deepseek-ai/DeepSeek-R1) and [DeepSeek-V3](https://huggingface.co/deepseek-ai/DeepSeek-V3) with vLLM on Ironwood (TPU v7x) using GKE.
+In this guide, we show how to serve and benchmark [DeepSeek-R1](https://huggingface.co/deepseek-ai/DeepSeek-R1) with vLLM on Ironwood (TPU v7x) using GKE.
 
-DeepSeek-R1 and DeepSeek-V3 are 671B parameter Mixture-of-Experts (MoE) models (37B active parameters per token) utilizing Multi-head Latent Attention (MLA). We deploy them on a single **tpu7x-standard-4t** node pool (4 TPU v7x chips, 8 TensorCores) using a **2x2x1** topology and **Tensor Parallelism (TP) size of 8**, using FP8 activation all-gather, FP4 weight requantization, and DP-attention sharding.
+DeepSeek-R1 is 671B parameter Mixture-of-Experts (MoE) models (37B active parameters per token) utilizing Multi-head Latent Attention (MLA). We deploy them on a single **tpu7x-standard-4t** node pool (4 TPU v7x chips, 8 TensorCores) using a **2x2x1** topology and **Tensor Parallelism (TP) size of 8**, using FP8 activation all-gather, FP4 weight requantization, and DP-attention sharding.
 
 ---
 
@@ -11,7 +11,6 @@ DeepSeek-R1 and DeepSeek-V3 are 671B parameter Mixture-of-Experts (MoE) models (
 | Model | Parameters | Active Parameters | Min TPUs (Chips) | Topology | Hugging Face |
 | :---- | :---- | :---- | :---- | :---- | :---- |
 | DeepSeek-R1 | 671B | 37B | 4× (tpu7x-standard-4t) | 2x2x1 | [deepseek-ai/DeepSeek-R1](https://huggingface.co/deepseek-ai/DeepSeek-R1) |
-| DeepSeek-V3 | 671B | 37B | 4× (tpu7x-standard-4t) | 2x2x1 | [deepseek-ai/DeepSeek-V3](https://huggingface.co/deepseek-ai/DeepSeek-V3) |
 
 ---
 

--- a/inference/ironwood/vLLM/DeepSeek-R1/README.md
+++ b/inference/ironwood/vLLM/DeepSeek-R1/README.md
@@ -1,0 +1,268 @@
+# Serve DeepSeek-R1 / DeepSeek-V3 with vLLM on Ironwood TPU
+
+In this guide, we show how to serve and benchmark [DeepSeek-R1](https://huggingface.co/deepseek-ai/DeepSeek-R1) and [DeepSeek-V3](https://huggingface.co/deepseek-ai/DeepSeek-V3) with vLLM on Ironwood (TPU v7x) using GKE.
+
+DeepSeek-R1 and DeepSeek-V3 are 671B parameter Mixture-of-Experts (MoE) models (37B active parameters per token) utilizing Multi-head Latent Attention (MLA). We deploy them on a single **tpu7x-standard-4t** node pool (4 TPU v7x chips, 8 TensorCores) using a **2x2x1** topology and **Tensor Parallelism (TP) size of 8**, using FP8 activation all-gather, FP4 weight requantization, and DP-attention sharding.
+
+---
+
+## Verified Models
+
+| Model | Parameters | Active Parameters | Min TPUs (Chips) | Topology | Hugging Face |
+| :---- | :---- | :---- | :---- | :---- | :---- |
+| DeepSeek-R1 | 671B | 37B | 4× (tpu7x-standard-4t) | 2x2x1 | [deepseek-ai/DeepSeek-R1](https://huggingface.co/deepseek-ai/DeepSeek-R1) |
+| DeepSeek-V3 | 671B | 37B | 4× (tpu7x-standard-4t) | 2x2x1 | [deepseek-ai/DeepSeek-V3](https://huggingface.co/deepseek-ai/DeepSeek-V3) |
+
+---
+
+## Prerequisites
+
+1. A GKE cluster with TPU v7x (Ironwood) support (GKE version `1.34.0-gke.2201000` or later).
+2. Google Cloud SDK (`gcloud`) and `kubectl` installed and configured.
+3. A Hugging Face account and access token for downloading model weights and tokenizer files.
+
+---
+
+## Step 1: Define Parameters
+
+Export the required environment variables for your GCP project and GKE cluster:
+
+```shell
+export PROJECT_ID="<YOUR_PROJECT_ID>"
+export CLUSTER_NAME="<YOUR_CLUSTER_NAME>"
+export REGION="<YOUR_REGION>"
+export ZONE="<YOUR_ZONE>"
+export NODEPOOL_NAME="deepseek-r1-tpu-pool"
+```
+
+---
+
+## Step 2: Create the TPU Node Pool
+
+Create a TPU v7x (Ironwood) node pool with the `tpu7x-standard-4t` machine type (4 chips / 8 TensorCores):
+
+```shell
+gcloud container node-pools create ${NODEPOOL_NAME} \
+    --project=${PROJECT_ID} \
+    --location=${REGION} \
+    --node-locations=${ZONE} \
+    --num-nodes=1 \
+    --machine-type=tpu7x-standard-4t \
+    --cluster=${CLUSTER_NAME}
+```
+
+---
+
+## Step 3: Setup Kubernetes Configurations
+
+1. Configure `kubectl` credentials:
+
+```shell
+gcloud container clusters get-credentials ${CLUSTER_NAME} --location=${ZONE} --project=${PROJECT_ID}
+```
+
+2. Create the `vllm-deepseek` namespace:
+
+```shell
+kubectl create namespace vllm-deepseek
+```
+
+3. Create the Hugging Face token secret:
+
+```shell
+export HF_TOKEN="<YOUR_HUGGING_FACE_TOKEN>"
+kubectl create secret generic hf-secret \
+    --namespace=vllm-deepseek \
+    --from-literal=hf_api_token=${HF_TOKEN}
+```
+
+---
+
+## Step 4: Apply the vLLM Server Manifest
+
+Apply the provided [deepseek_r1-server.yaml](./deepseek_r1-server.yaml) manifest:
+
+```shell
+kubectl apply -f deepseek_r1-server.yaml
+```
+
+Monitor pod status:
+
+```shell
+kubectl get pods -n vllm-deepseek -w
+```
+
+Stream server logs:
+
+```shell
+kubectl logs -n vllm-deepseek deployment/vllm-deepseek-r1 -c vllm-tpu -f
+```
+
+When startup is complete, you should see:
+
+```text
+(APIServer pid=1) INFO:     Started server process [1]
+(APIServer pid=1) INFO:     Waiting for application startup.
+(APIServer pid=1) INFO:     Application startup complete.
+```
+
+---
+
+## Step 5: Interact with the Model
+
+1. Port-forward the vLLM service locally:
+
+```shell
+kubectl port-forward -n vllm-deepseek service/vllm-deepseek-r1-service 8000:8000
+```
+
+2. Send a test request using `curl`:
+
+```shell
+curl http://localhost:8000/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+        "model": "deepseek-ai/DeepSeek-R1",
+        "messages": [
+            {"role": "user", "content": "What is the capital of France? Think step by step."}
+        ],
+        "max_tokens": 256,
+        "temperature": 0.6
+    }'
+```
+
+---
+
+## Step 6: Run Serving Benchmarks
+
+We use the `InferenceX` benchmarking client to evaluate serving throughput and latency for a **1K Input / 1K Output (1k/1k)** workload.
+
+### Benchmark Manifest
+
+Save the following manifest as `deepseek_r1-benchmark.yaml`:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: deepseek-r1-bench
+  namespace: vllm-deepseek
+spec:
+  restartPolicy: Never
+  terminationGracePeriodSeconds: 60
+  containers:
+  - name: vllm-bench
+    image: vllm/vllm-tpu:nightly-20260626-c539adc-cc79815
+    command: ["/bin/bash", "-c"]
+    args:
+    - |
+      while ! curl -s http://vllm-deepseek-r1-service:8000/ping; do sleep 30 && echo 'Waiting for server...'; done
+      apt-get update && apt-get install -y git && \
+      git clone https://github.com/SemiAnalysisAI/InferenceX.git /tmp/inferencex && \
+      cd /tmp/inferencex && \
+      git checkout 89ce6098ef2bc4576a735c43f39c7d972b091cfc && \
+      python3 /tmp/inferencex/utils/bench_serving/benchmark_serving.py \
+        --backend=vllm \
+        --request-rate=inf \
+        --percentile-metrics='ttft,tpot,itl,e2el' \
+        --host=vllm-deepseek-r1-service \
+        --port=8000 \
+        --model=deepseek-ai/DeepSeek-R1 \
+        --tokenizer=deepseek-ai/DeepSeek-R1 \
+        --dataset-name=random \
+        --random-input-len=1024 \
+        --random-output-len=1024 \
+        --random-range-ratio=0.8 \
+        --num-prompts=512 \
+        --max-concurrency=128 \
+        --ignore-eos
+    env:
+    - name: HUGGING_FACE_HUB_TOKEN
+      valueFrom:
+        secretKeyRef:
+          key: hf_api_token
+          name: hf-secret
+```
+
+Apply the benchmark pod:
+
+```shell
+kubectl apply -f deepseek_r1-benchmark.yaml
+```
+
+View the benchmark output logs:
+
+```shell
+kubectl logs -n vllm-deepseek deepseek-r1-bench -f
+```
+
+### Benchmark Results
+
+#### Example Benchmark Output
+
+```
+============ Serving Benchmark Result ============
+Successful requests:                     504
+Failed requests:                         8
+Maximum request concurrency:             128
+Benchmark duration (s):                  434.28
+Total input tokens:                      516096
+Total generated tokens:                  516096
+Request throughput (req/s):              1.16
+Output token throughput (tok/s):         1188.39
+Peak output token throughput (tok/s):    19624.00
+Peak concurrent requests:                170.00
+Total token throughput (tok/s):          2376.78
+---------------Time to First Token----------------
+Mean TTFT (ms):                          14343.53
+Median TTFT (ms):                        13775.80
+P99 TTFT (ms):                           93084.55
+-----Time per Output Token (excl. 1st token)------
+Mean TPOT (ms):                          80.50
+Median TPOT (ms):                        74.69
+P99 TPOT (ms):                           137.32
+---------------Inter-token Latency----------------
+Mean ITL (ms):                           80.50
+Median ITL (ms):                         0.01
+P99 ITL (ms):                            271.92
+----------------End-to-end Latency----------------
+Mean E2EL (ms):                          96699.08
+Median E2EL (ms):                        81872.88
+P99 E2EL (ms):                           207312.47
+==================================================
+```
+
+#### Summary Metrics
+
+| Workload (Input / Output) | Output Token Throughput (Total) | Output Token Throughput (Per Chip) | Mean TTFT | Mean TPOT | Mean ITL |
+| :------------------------ | :------------------------------ | :--------------------------------- | :-------- | :-------- | :------- |
+| 1k / 1k                   | 1188.39 tok/s                   | 297.10 tok/s/chip                  | 14.34 s   | 80.50 ms  | 80.50 ms |
+
+**Note**: These benchmark results are measured using the vLLM benchmark client on a single-node Ironwood TPU v7x (topology `2x2x1`, 4 chips / 8 TensorCores) with FP8 KV cache, FP4 weight requantization, and DP-attention sharding. The development team is continuously optimizing performance; results are subject to change as newer software versions and compiler optimizations are released.
+
+Clean up the benchmark pod when finished:
+
+```shell
+kubectl delete -f deepseek_r1-benchmark.yaml
+```
+
+---
+
+## Step 7: Cleanup
+
+When you are done testing, delete the server and the node pool:
+
+1. Delete the Kubernetes deployment and resources:
+
+```shell
+kubectl delete -f deepseek_r1-server.yaml
+```
+
+2. (Optional) Delete the TPU node pool:
+
+```shell
+gcloud container node-pools delete ${NODEPOOL_NAME} \
+    --cluster=${CLUSTER_NAME} \
+    --location=${REGION} \
+    --project=${PROJECT_ID}
+```

--- a/inference/ironwood/vLLM/DeepSeek-R1/deepseek_r1-server.yaml
+++ b/inference/ironwood/vLLM/DeepSeek-R1/deepseek_r1-server.yaml
@@ -99,10 +99,12 @@ spec:
           requests:
             google.com/tpu: '4'
         readinessProbe:
-          tcpSocket:
+          httpGet:
+            path: /health
             port: 8000
-          initialDelaySeconds: 30
-          periodSeconds: 10
+          initialDelaySeconds: 120
+          periodSeconds: 15
+          failureThreshold: 30
         volumeMounts:
         - mountPath: "/data"
           name: data-volume

--- a/inference/ironwood/vLLM/DeepSeek-R1/deepseek_r1-server.yaml
+++ b/inference/ironwood/vLLM/DeepSeek-R1/deepseek_r1-server.yaml
@@ -1,0 +1,132 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vllm-deepseek
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: hyperdisk-balanced-deepseek
+provisioner: pd.csi.storage.gke.io
+parameters:
+  type: hyperdisk-balanced
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hd-claim-deepseek-r1
+  namespace: vllm-deepseek
+spec:
+  storageClassName: hyperdisk-balanced-deepseek
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1500Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-deepseek-r1
+  namespace: vllm-deepseek
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vllm-deepseek-r1
+  template:
+    metadata:
+      labels:
+        app: vllm-deepseek-r1
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 2x2x1
+      containers:
+      - name: vllm-tpu
+        image: vllm/vllm-tpu:nightly-20260626-c539adc-cc79815
+        command: ["vllm", "serve"]
+        args:
+        - --host=0.0.0.0
+        - --port=8000
+        - --model=deepseek-ai/DeepSeek-R1
+        - --tokenizer=deepseek-ai/DeepSeek-R1
+        - --load-format=runai_streamer
+        - --tensor-parallel-size=8
+        - --kv-cache-dtype=fp8
+        - --max-model-len=9216
+        - --gpu-memory-utilization=0.95
+        - --max-num-seqs=128
+        - --max-num-batched-tokens=1024
+        - --enable-expert-parallel
+        - --async-scheduling
+        - '--additional-config={"sharding": {"sharding_strategy": {"enable_dp_attention": true}}}'
+        - --download-dir=/data
+        env:
+        - name: MOE_ALL_GATHER_ACTIVATION_DTYPE
+          value: "fp8"
+        - name: MOE_REQUANTIZE_WEIGHT_DTYPE
+          value: "fp4"
+        - name: MOE_REQUANTIZE_BLOCK_SIZE
+          value: "512"
+        - name: NEW_MODEL_DESIGN
+          value: "1"
+        - name: MODEL_IMPL_TYPE
+          value: "vllm"
+        - name: TPU_BACKEND_TYPE
+          value: "jax"
+        - name: VLLM_DISABLE_SHARED_EXPERTS_STREAM
+          value: "1"
+        - name: VLLM_TORCH_COMPILE_CACHE_DIR
+          value: "/data/torch_compile_cache"
+        - name: XLA_CACHE_DIR
+          value: "/data/xla_cache"
+        - name: HF_HOME
+          value: /data
+        - name: HF_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: hf-secret
+              key: hf_api_token
+        ports:
+        - containerPort: 8000
+        resources:
+          limits:
+            google.com/tpu: '4'
+          requests:
+            google.com/tpu: '4'
+        readinessProbe:
+          tcpSocket:
+            port: 8000
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        volumeMounts:
+        - mountPath: "/data"
+          name: data-volume
+        - mountPath: /dev/shm
+          name: dshm
+      volumes:
+      - emptyDir:
+          medium: Memory
+        name: dshm
+      - name: data-volume
+        persistentVolumeClaim:
+          claimName: hd-claim-deepseek-r1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm-deepseek-r1-service
+  namespace: vllm-deepseek
+spec:
+  selector:
+    app: vllm-deepseek-r1
+  type: ClusterIP
+  ports:
+  - name: http
+    protocol: TCP
+    port: 8000
+    targetPort: 8000

--- a/inference/ironwood/vLLM/DeepSeek-V3/README.md
+++ b/inference/ironwood/vLLM/DeepSeek-V3/README.md
@@ -1,8 +1,8 @@
-# Serve DeepSeek-V3 / DeepSeek-R1 with vLLM on Ironwood TPU
+# Serve DeepSeek-V3 with vLLM on Ironwood TPU
 
-In this guide, we show how to serve and benchmark [DeepSeek-V3](https://huggingface.co/deepseek-ai/DeepSeek-V3) and [DeepSeek-R1](https://huggingface.co/deepseek-ai/DeepSeek-R1) with vLLM on Ironwood (TPU v7x) using GKE.
+In this guide, we show how to serve and benchmark [DeepSeek-V3](https://huggingface.co/deepseek-ai/DeepSeek-V3) with vLLM on Ironwood (TPU v7x) using GKE.
 
-DeepSeek-V3 and DeepSeek-R1 are 671B parameter Mixture-of-Experts (MoE) models (37B active parameters per token) utilizing Multi-head Latent Attention (MLA). We deploy them on a single **tpu7x-standard-4t** node pool (4 TPU v7x chips, 8 TensorCores) using a **2x2x1** topology and **Tensor Parallelism (TP) size of 8**, using FP8 activation all-gather, FP4 weight requantization, and DP-attention sharding.
+DeepSeek-V3 is 671B parameter Mixture-of-Experts (MoE) models (37B active parameters per token) utilizing Multi-head Latent Attention (MLA). We deploy them on a single **tpu7x-standard-4t** node pool (4 TPU v7x chips, 8 TensorCores) using a **2x2x1** topology and **Tensor Parallelism (TP) size of 8**, using FP8 activation all-gather, FP4 weight requantization, and DP-attention sharding.
 
 ---
 
@@ -11,7 +11,6 @@ DeepSeek-V3 and DeepSeek-R1 are 671B parameter Mixture-of-Experts (MoE) models (
 | Model | Parameters | Active Parameters | Min TPUs (Chips) | Topology | Hugging Face |
 | :---- | :---- | :---- | :---- | :---- | :---- |
 | DeepSeek-V3 | 671B | 37B | 4× (tpu7x-standard-4t) | 2x2x1 | [deepseek-ai/DeepSeek-V3](https://huggingface.co/deepseek-ai/DeepSeek-V3) |
-| DeepSeek-R1 | 671B | 37B | 4× (tpu7x-standard-4t) | 2x2x1 | [deepseek-ai/DeepSeek-R1](https://huggingface.co/deepseek-ai/DeepSeek-R1) |
 
 ---
 

--- a/inference/ironwood/vLLM/DeepSeek-V3/README.md
+++ b/inference/ironwood/vLLM/DeepSeek-V3/README.md
@@ -156,7 +156,7 @@ spec:
     command: ["/bin/bash", "-c"]
     args:
     - |
-      while ! curl -s http://vllm-deepseek-v3-service:8000/ping; do sleep 30 && echo 'Waiting for server...'; done
+      while ! curl -s -f http://vllm-deepseek-v3-service:8000/health; do sleep 30 && echo 'Waiting for server...'; done
       apt-get update && apt-get install -y git && \
       git clone https://github.com/SemiAnalysisAI/InferenceX.git /tmp/inferencex && \
       cd /tmp/inferencex && \

--- a/inference/ironwood/vLLM/DeepSeek-V3/README.md
+++ b/inference/ironwood/vLLM/DeepSeek-V3/README.md
@@ -1,0 +1,268 @@
+# Serve DeepSeek-V3 / DeepSeek-R1 with vLLM on Ironwood TPU
+
+In this guide, we show how to serve and benchmark [DeepSeek-V3](https://huggingface.co/deepseek-ai/DeepSeek-V3) and [DeepSeek-R1](https://huggingface.co/deepseek-ai/DeepSeek-R1) with vLLM on Ironwood (TPU v7x) using GKE.
+
+DeepSeek-V3 and DeepSeek-R1 are 671B parameter Mixture-of-Experts (MoE) models (37B active parameters per token) utilizing Multi-head Latent Attention (MLA). We deploy them on a single **tpu7x-standard-4t** node pool (4 TPU v7x chips, 8 TensorCores) using a **2x2x1** topology and **Tensor Parallelism (TP) size of 8**, using FP8 activation all-gather, FP4 weight requantization, and DP-attention sharding.
+
+---
+
+## Verified Models
+
+| Model | Parameters | Active Parameters | Min TPUs (Chips) | Topology | Hugging Face |
+| :---- | :---- | :---- | :---- | :---- | :---- |
+| DeepSeek-V3 | 671B | 37B | 4× (tpu7x-standard-4t) | 2x2x1 | [deepseek-ai/DeepSeek-V3](https://huggingface.co/deepseek-ai/DeepSeek-V3) |
+| DeepSeek-R1 | 671B | 37B | 4× (tpu7x-standard-4t) | 2x2x1 | [deepseek-ai/DeepSeek-R1](https://huggingface.co/deepseek-ai/DeepSeek-R1) |
+
+---
+
+## Prerequisites
+
+1. A GKE cluster with TPU v7x (Ironwood) support (GKE version `1.34.0-gke.2201000` or later).
+2. Google Cloud SDK (`gcloud`) and `kubectl` installed and configured.
+3. A Hugging Face account and access token for downloading model weights and tokenizer files.
+
+---
+
+## Step 1: Define Parameters
+
+Export the required environment variables for your GCP project and GKE cluster:
+
+```shell
+export PROJECT_ID="<YOUR_PROJECT_ID>"
+export CLUSTER_NAME="<YOUR_CLUSTER_NAME>"
+export REGION="<YOUR_REGION>"
+export ZONE="<YOUR_ZONE>"
+export NODEPOOL_NAME="deepseek-v3-tpu-pool"
+```
+
+---
+
+## Step 2: Create the TPU Node Pool
+
+Create a TPU v7x (Ironwood) node pool with the `tpu7x-standard-4t` machine type (4 chips / 8 TensorCores):
+
+```shell
+gcloud container node-pools create ${NODEPOOL_NAME} \
+    --project=${PROJECT_ID} \
+    --location=${REGION} \
+    --node-locations=${ZONE} \
+    --num-nodes=1 \
+    --machine-type=tpu7x-standard-4t \
+    --cluster=${CLUSTER_NAME}
+```
+
+---
+
+## Step 3: Setup Kubernetes Configurations
+
+1. Configure `kubectl` credentials:
+
+```shell
+gcloud container clusters get-credentials ${CLUSTER_NAME} --location=${ZONE} --project=${PROJECT_ID}
+```
+
+2. Create the `vllm-deepseek` namespace:
+
+```shell
+kubectl create namespace vllm-deepseek
+```
+
+3. Create the Hugging Face token secret:
+
+```shell
+export HF_TOKEN="<YOUR_HUGGING_FACE_TOKEN>"
+kubectl create secret generic hf-secret \
+    --namespace=vllm-deepseek \
+    --from-literal=hf_api_token=${HF_TOKEN}
+```
+
+---
+
+## Step 4: Apply the vLLM Server Manifest
+
+Apply the provided [deepseek_v3-server.yaml](./deepseek_v3-server.yaml) manifest:
+
+```shell
+kubectl apply -f deepseek_v3-server.yaml
+```
+
+Monitor pod status:
+
+```shell
+kubectl get pods -n vllm-deepseek -w
+```
+
+Stream server logs:
+
+```shell
+kubectl logs -n vllm-deepseek deployment/vllm-deepseek-v3 -c vllm-tpu -f
+```
+
+When startup is complete, you should see:
+
+```text
+(APIServer pid=1) INFO:     Started server process [1]
+(APIServer pid=1) INFO:     Waiting for application startup.
+(APIServer pid=1) INFO:     Application startup complete.
+```
+
+---
+
+## Step 5: Interact with the Model
+
+1. Port-forward the vLLM service locally:
+
+```shell
+kubectl port-forward -n vllm-deepseek service/vllm-deepseek-v3-service 8000:8000
+```
+
+2. Send a test request using `curl`:
+
+```shell
+curl http://localhost:8000/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+        "model": "deepseek-ai/DeepSeek-V3",
+        "messages": [
+            {"role": "user", "content": "Explain Mixture-of-Experts architecture in two sentences."}
+        ],
+        "max_tokens": 128,
+        "temperature": 0.7
+    }'
+```
+
+---
+
+## Step 6: Run Serving Benchmarks
+
+We use the `InferenceX` benchmarking client to evaluate serving throughput and latency for a **1K Input / 1K Output (1k/1k)** workload.
+
+### Benchmark Manifest
+
+Save the following manifest as `deepseek_v3-benchmark.yaml`:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: deepseek-v3-bench
+  namespace: vllm-deepseek
+spec:
+  restartPolicy: Never
+  terminationGracePeriodSeconds: 60
+  containers:
+  - name: vllm-bench
+    image: vllm/vllm-tpu:nightly-20260626-c539adc-cc79815
+    command: ["/bin/bash", "-c"]
+    args:
+    - |
+      while ! curl -s http://vllm-deepseek-v3-service:8000/ping; do sleep 30 && echo 'Waiting for server...'; done
+      apt-get update && apt-get install -y git && \
+      git clone https://github.com/SemiAnalysisAI/InferenceX.git /tmp/inferencex && \
+      cd /tmp/inferencex && \
+      git checkout 89ce6098ef2bc4576a735c43f39c7d972b091cfc && \
+      python3 /tmp/inferencex/utils/bench_serving/benchmark_serving.py \
+        --backend=vllm \
+        --request-rate=inf \
+        --percentile-metrics='ttft,tpot,itl,e2el' \
+        --host=vllm-deepseek-v3-service \
+        --port=8000 \
+        --model=deepseek-ai/DeepSeek-V3 \
+        --tokenizer=deepseek-ai/DeepSeek-V3 \
+        --dataset-name=random \
+        --random-input-len=1024 \
+        --random-output-len=1024 \
+        --random-range-ratio=0.8 \
+        --num-prompts=512 \
+        --max-concurrency=128 \
+        --ignore-eos
+    env:
+    - name: HUGGING_FACE_HUB_TOKEN
+      valueFrom:
+        secretKeyRef:
+          key: hf_api_token
+          name: hf-secret
+```
+
+Apply the benchmark pod:
+
+```shell
+kubectl apply -f deepseek_v3-benchmark.yaml
+```
+
+View the benchmark output logs:
+
+```shell
+kubectl logs -n vllm-deepseek deepseek-v3-bench -f
+```
+
+### Benchmark Results
+
+#### Example Benchmark Output
+
+```
+============ Serving Benchmark Result ============
+Successful requests:                     512
+Failed requests:                         0
+Maximum request concurrency:             128
+Benchmark duration (s):                  262.17
+Total input tokens:                      524288
+Total generated tokens:                  524288
+Request throughput (req/s):              1.95
+Output token throughput (tok/s):         1999.78
+Peak output token throughput (tok/s):    18541.00
+Peak concurrent requests:                142.00
+Total token throughput (tok/s):          3999.57
+---------------Time to First Token----------------
+Mean TTFT (ms):                          4936.54
+Median TTFT (ms):                        5113.73
+P99 TTFT (ms):                           7817.15
+-----Time per Output Token (excl. 1st token)------
+Mean TPOT (ms):                          55.07
+Median TPOT (ms):                        52.16
+P99 TPOT (ms):                           85.77
+---------------Inter-token Latency----------------
+Mean ITL (ms):                           55.07
+Median ITL (ms):                         0.01
+P99 ITL (ms):                            424.88
+----------------End-to-end Latency----------------
+Mean E2EL (ms):                          61277.17
+Median E2EL (ms):                        56231.60
+P99 E2EL (ms):                           92034.03
+==================================================
+```
+
+#### Summary Metrics
+
+| Workload (Input / Output) | Output Token Throughput (Total) | Output Token Throughput (Per Chip) | Mean TTFT | Mean TPOT | Mean ITL |
+| :------------------------ | :------------------------------ | :--------------------------------- | :-------- | :-------- | :------- |
+| 1k / 1k                   | 1999.78 tok/s                   | 499.95 tok/s/chip                  | 4.94 s    | 55.07 ms  | 55.07 ms |
+
+**Note**: These benchmark results are measured using the vLLM benchmark client on a single-node Ironwood TPU v7x (topology `2x2x1`, 4 chips / 8 TensorCores) with FP8 KV cache, FP4 weight requantization, and DP-attention sharding. The development team is continuously optimizing performance; results are subject to change as newer software versions and compiler optimizations are released.
+
+Clean up the benchmark pod when finished:
+
+```shell
+kubectl delete -f deepseek_v3-benchmark.yaml
+```
+
+---
+
+## Step 7: Cleanup
+
+When you are done testing, delete the server and the node pool:
+
+1. Delete the Kubernetes deployment and resources:
+
+```shell
+kubectl delete -f deepseek_v3-server.yaml
+```
+
+2. (Optional) Delete the TPU node pool:
+
+```shell
+gcloud container node-pools delete ${NODEPOOL_NAME} \
+    --cluster=${CLUSTER_NAME} \
+    --location=${REGION} \
+    --project=${PROJECT_ID}
+```

--- a/inference/ironwood/vLLM/DeepSeek-V3/deepseek_v3-server.yaml
+++ b/inference/ironwood/vLLM/DeepSeek-V3/deepseek_v3-server.yaml
@@ -99,10 +99,12 @@ spec:
           requests:
             google.com/tpu: '4'
         readinessProbe:
-          tcpSocket:
+          httpGet:
+            path: /health
             port: 8000
-          initialDelaySeconds: 30
-          periodSeconds: 10
+          initialDelaySeconds: 120
+          periodSeconds: 15
+          failureThreshold: 30
         volumeMounts:
         - mountPath: "/data"
           name: data-volume

--- a/inference/ironwood/vLLM/DeepSeek-V3/deepseek_v3-server.yaml
+++ b/inference/ironwood/vLLM/DeepSeek-V3/deepseek_v3-server.yaml
@@ -1,0 +1,132 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vllm-deepseek
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: hyperdisk-balanced-deepseek
+provisioner: pd.csi.storage.gke.io
+parameters:
+  type: hyperdisk-balanced
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hd-claim-deepseek-v3
+  namespace: vllm-deepseek
+spec:
+  storageClassName: hyperdisk-balanced-deepseek
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1500Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-deepseek-v3
+  namespace: vllm-deepseek
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vllm-deepseek-v3
+  template:
+    metadata:
+      labels:
+        app: vllm-deepseek-v3
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 2x2x1
+      containers:
+      - name: vllm-tpu
+        image: vllm/vllm-tpu:nightly-20260626-c539adc-cc79815
+        command: ["vllm", "serve"]
+        args:
+        - --host=0.0.0.0
+        - --port=8000
+        - --model=deepseek-ai/DeepSeek-V3
+        - --tokenizer=deepseek-ai/DeepSeek-V3
+        - --load-format=runai_streamer
+        - --tensor-parallel-size=8
+        - --kv-cache-dtype=fp8
+        - --max-model-len=9216
+        - --gpu-memory-utilization=0.95
+        - --max-num-seqs=128
+        - --max-num-batched-tokens=1024
+        - --enable-expert-parallel
+        - --async-scheduling
+        - '--additional-config={"sharding": {"sharding_strategy": {"enable_dp_attention": true}}}'
+        - --download-dir=/data
+        env:
+        - name: MOE_ALL_GATHER_ACTIVATION_DTYPE
+          value: "fp8"
+        - name: MOE_REQUANTIZE_WEIGHT_DTYPE
+          value: "fp4"
+        - name: MOE_REQUANTIZE_BLOCK_SIZE
+          value: "512"
+        - name: NEW_MODEL_DESIGN
+          value: "1"
+        - name: MODEL_IMPL_TYPE
+          value: "vllm"
+        - name: TPU_BACKEND_TYPE
+          value: "jax"
+        - name: VLLM_DISABLE_SHARED_EXPERTS_STREAM
+          value: "1"
+        - name: VLLM_TORCH_COMPILE_CACHE_DIR
+          value: "/data/torch_compile_cache"
+        - name: XLA_CACHE_DIR
+          value: "/data/xla_cache"
+        - name: HF_HOME
+          value: /data
+        - name: HF_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: hf-secret
+              key: hf_api_token
+        ports:
+        - containerPort: 8000
+        resources:
+          limits:
+            google.com/tpu: '4'
+          requests:
+            google.com/tpu: '4'
+        readinessProbe:
+          tcpSocket:
+            port: 8000
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        volumeMounts:
+        - mountPath: "/data"
+          name: data-volume
+        - mountPath: /dev/shm
+          name: dshm
+      volumes:
+      - emptyDir:
+          medium: Memory
+        name: dshm
+      - name: data-volume
+        persistentVolumeClaim:
+          claimName: hd-claim-deepseek-v3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm-deepseek-v3-service
+  namespace: vllm-deepseek
+spec:
+  selector:
+    app: vllm-deepseek-v3
+  type: ClusterIP
+  ports:
+  - name: http
+    protocol: TCP
+    port: 8000
+    targetPort: 8000


### PR DESCRIPTION
## Description

Feature Request Bug: https://buganizer.corp.google.com/issues/546220310

This PR introduces end-to-end inference serving and benchmarking recipes for **DeepSeek-R1** and **DeepSeek-V3** (671B Mixture-of-Experts) with **vLLM** on **Google Cloud TPU Ironwood (TPU v7x)** using GKE.

Both recipes provide complete standalone Kubernetes manifests and step-by-step reproduction instructions covering cluster node pool setup, storage provisioning via Hyperdisk Balanced, serving deployments, and performance benchmarking.

---

## Key Highlights & Architecture

- **Hardware Topology**: Single-node **`tpu7x-standard-4t`** pool (4 TPU v7x chips, 8 TensorCores) configured with topology **`2x2x1`**.
- **Parallelism & Sharding Strategy**:
  - **Tensor Parallelism (TP)**: `tensor-parallel-size=8`
  - **Expert Parallelism (EP)**: `--enable-expert-parallel` with JAX GMM EP kernels
  - **Data Parallel Attention**: `enable_dp_attention: true` with asynchronous scheduling
- **Quantization & Memory Optimizations**:
  - **KV Cache**: FP8 (`--kv-cache-dtype=fp8`)
  - **Weight Requantization**: FP4 with block size 512 (`MOE_REQUANTIZE_WEIGHT_DTYPE=fp4`, `MOE_REQUANTIZE_BLOCK_SIZE=512`)
  - **Activation Type**: FP8 all-gather (`MOE_ALL_GATHER_ACTIVATION_DTYPE=fp8`)
- **Storage**: 1500Gi `hyperdisk-balanced` PVC with `WaitForFirstConsumer` binding to accommodate model weights and compiler caches.

---

## Measured Benchmark Results

Serving benchmarks were conducted on a live GKE cluster (`bodaborg-tpu7x-nap`) using the vLLM serving benchmark client under a **1K Input / 1K Output (1k/1k)** workload with **concurrency = 128** across **512 prompts**:

| Model | Total Output Throughput | Per-Chip Throughput | Mean TTFT | Mean TPOT | Mean ITL | Mean E2EL |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| **DeepSeek-R1** | **1,188.39 tok/s** | **297.10 tok/s/chip** | 14.34 s | 80.50 ms | 80.50 ms | 96.70 s |
| **DeepSeek-V3** | **1,999.78 tok/s** | **499.95 tok/s/chip** | 4.94 s | 55.07 ms | 55.07 ms | 61.28 s |

*Full raw stdout logs from the benchmark runs are included in the respective README files.*

---

## Directory Structure

inference/ironwood/vLLM/DeepSeek-R1/
- deepseek_r1-server.yaml
- README.md

inference/ironwood/vLLM/DeepSeek-V3/
- deepseek_v3-server.yaml
- README.md

---

## Checklist
- [x] Zero Secret Policy: verified no hardcoded tokens, internal credentials, or service accounts.
- [x] Verified zero internal dependencies (pure Kubernetes manifests with upstream `vllm/vllm-tpu` image).
- [x] Full reproduction documentation and raw benchmark results included.